### PR TITLE
feat: add support for dots in property names for OTEL compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Properties are extracted from templates and matched positionally to arguments
 - Templates serve as both human-readable messages and event types for grouping/analysis
 - Support for format specifiers like `{Count:000}` and `{Price:F2}`
+- OTEL-compatible dotted property names like `{http.method}`, `{service.name}`, `{db.system}`
 
 ### 2. Pipeline Architecture
 The logging pipeline follows this flow:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ mtlog is a high-performance structured logging library for Go, inspired by [Seri
 - **Zero-allocation logging** for simple messages (17.3 ns/op)
 - **Message templates** with positional property extraction and format specifiers
 - **Go template syntax** support (`{{.Property}}`) alongside traditional syntax
+- **OpenTelemetry compatibility** with support for dotted property names (`{http.method}`, `{service.name}`)
 - **Output templates** for customizable log formatting
 - **ForType logging** with automatic SourceContext from Go types and intelligent caching
 - **LogContext scoped properties** that flow through operation contexts
@@ -98,6 +99,10 @@ log.Information("User {UserId} logged in from {IP}", userId, ipAddress)
 
 // Go template syntax is also supported
 log.Information("User {{.UserId}} logged in from {{.IP}}", userId, ipAddress)
+
+// OTEL-style dotted properties for compatibility with OpenTelemetry conventions
+log.Information("HTTP {http.method} to {http.url} returned {http.status_code}", "GET", "/api", 200)
+log.Information("Service {service.name} in {service.namespace}", "api", "production")
 
 // Mix both syntaxes as needed
 log.Information("User {UserId} ({{.Username}}) from {IP}", userId, username, ipAddress)

--- a/cmd/mtlog-analyzer/analyzer/analyzer.go
+++ b/cmd/mtlog-analyzer/analyzer/analyzer.go
@@ -630,6 +630,11 @@ func checkPropertyNamingWithConfig(pass *analysis.Pass, call *ast.CallExpr, temp
 		
 		// Suggest PascalCase for property names
 		if len(propName) > 0 && propName[0] >= 'a' && propName[0] <= 'z' {
+			// Skip OTEL-style dotted properties (they follow different conventions)
+			if strings.Contains(propName, ".") {
+				continue
+			}
+			
 			// Skip if we've already suggested a fix for this property
 			if suggested[propName] {
 				continue

--- a/cmd/mtlog-analyzer/analyzer/dots_test.go
+++ b/cmd/mtlog-analyzer/analyzer/dots_test.go
@@ -1,0 +1,12 @@
+package analyzer_test
+
+import (
+	"testing"
+	"github.com/willibrandon/mtlog/cmd/mtlog-analyzer/analyzer"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestDotsInPropertyNames(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, analyzer.Analyzer, "dots")
+}

--- a/cmd/mtlog-analyzer/analyzer/testdata/src/dots/dots.go
+++ b/cmd/mtlog-analyzer/analyzer/testdata/src/dots/dots.go
@@ -1,0 +1,69 @@
+// Package dots tests the analyzer's handling of dotted property names
+package dots
+
+// Ensure we test dotted properties work correctly
+
+// Logger mimics the mtlog logger interface for testing
+type Logger struct{}
+
+func (l *Logger) Verbose(template string, args ...interface{})     {}
+func (l *Logger) V(template string, args ...interface{})           {}
+func (l *Logger) Debug(template string, args ...interface{})       {}
+func (l *Logger) D(template string, args ...interface{})           {}
+func (l *Logger) Information(template string, args ...interface{}) {}
+func (l *Logger) Info(template string, args ...interface{})        {}
+func (l *Logger) I(template string, args ...interface{})           {}
+func (l *Logger) Warning(template string, args ...interface{})     {}
+func (l *Logger) Warn(template string, args ...interface{})        {}
+func (l *Logger) W(template string, args ...interface{})           {}
+func (l *Logger) Error(template string, args ...interface{})       {}
+func (l *Logger) Err(template string, args ...interface{})         {}
+func (l *Logger) E(template string, args ...interface{})           {}
+func (l *Logger) Fatal(template string, args ...interface{})       {}
+func (l *Logger) F(template string, args ...interface{})           {}
+func (l *Logger) ForContext(key string, value interface{}) *Logger { return l }
+
+func testAll() {
+	log := &Logger{}
+	
+	// Valid OTEL-style properties
+	log.Information("HTTP request {http.method} to {http.url} took {http.duration.ms}ms", "GET", "/api/users", 123.45)
+	log.Information("Database {db.system} query to {db.name}", "postgres", "users")
+	log.Information("Service {service.name} version {service.version}", "api", "1.0.0")
+	
+	// Dotted properties with format specifiers
+	log.Information("Duration: {http.duration.ms:F2}ms", 123.456)
+	log.Information("Status code: {http.status.code:000}", 200)
+	
+	// Dotted properties with destructuring
+	userProfile := struct {
+		Name  string
+		Email string
+	}{
+		Name:  "John",
+		Email: "john@example.com",
+	}
+	statusObj := 200
+	log.Information("User profile: {@user.profile.data}", userProfile)
+	log.Information("Status: {$http.response.status}", statusObj)
+	
+	// Mixed regular and dotted properties
+	log.Information("User {UserId} made {http.method} request", 123, "POST")
+	
+	// Edge cases that should still work
+	log.Information("Property {ends.with.dot.}", "value")
+	log.Information("Property {has..consecutive..dots}", "value")
+	
+	// Should detect template/argument mismatch with dotted properties
+	log.Information("Missing arg {http.method}") // want "template has 1 properties but 0 arguments provided"
+	log.Information("Extra args {http.method}", "GET", "extra") // want "template has 1 properties but 2 arguments provided"
+	
+	// Should detect duplicate dotted properties
+	log.Information("Duplicate {http.method} and {http.method}", "GET", "POST") // want "duplicate property 'http.method'"
+	
+	// OTEL-style dotted properties should NOT suggest PascalCase
+	log.Information("User {user.id} logged in", 123) // OK - OTEL style
+	
+	// But non-dotted lowercase properties should still suggest PascalCase
+	log.Information("User {userid} logged in", 123) // want "suggestion: consider using PascalCase for property 'userid'"
+}

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -1,0 +1,56 @@
+// Package main demonstrates using OTEL-style dotted property names with mtlog.
+package main
+
+import (
+	"time"
+	
+	"github.com/willibrandon/mtlog"
+)
+
+func main() {
+	// Create a logger with console output
+	log := mtlog.New(
+		mtlog.WithConsole(),
+	)
+	
+	// Log with OTEL-style dotted properties
+	log.Information("HTTP request {http.method} to {http.url} returned {http.status_code} in {http.duration.ms:F2}ms",
+		"GET", "/api/users", 200, 123.456)
+	
+	// Service metadata using OTEL conventions
+	log.Information("Service {service.name} version {service.version} started in {service.namespace}",
+		"user-api", "2.1.0", "production")
+	
+	// Database operations with OTEL conventions
+	log.Information("Database {db.system} query {db.operation} on {db.name} took {db.duration.ms:F1}ms",
+		"postgresql", "SELECT", "users", 45.8)
+	
+	// Trace context with dots
+	traceLog := log.ForContext("trace.id", "abc123").
+		ForContext("trace.span_id", "span456")
+	
+	traceLog.Information("Processing request in span")
+	
+	// Mix traditional PascalCase with OTEL-style
+	log.Information("User {UserId} made {http.method} request to {http.url} from {client.ip}",
+		123, "POST", "/api/orders", "192.168.1.100")
+	
+	// Error tracking with OTEL conventions
+	log.Error("Failed to connect to {db.system} at {db.connection_string}: {error.message}",
+		"redis", "redis://localhost:6379", "connection refused")
+	
+	// Metrics-style properties
+	log.Information("Cache hit rate: {cache.hit_rate:P1}, Items: {cache.item_count}",
+		0.856, 1542)
+	
+	time.Sleep(100 * time.Millisecond) // Give console time to flush
+}
+
+// Example output:
+// 2025-07-29 10:15:23 [INF] HTTP request GET to /api/users returned 200 in 123.46ms
+// 2025-07-29 10:15:23 [INF] Service user-api version 2.1.0 started in production
+// 2025-07-29 10:15:23 [INF] Database postgresql query SELECT on users took 45.8ms
+// 2025-07-29 10:15:23 [INF] Processing request in span (trace.id: abc123, trace.span_id: span456)
+// 2025-07-29 10:15:23 [INF] User 123 made POST request to /api/orders from 192.168.1.100
+// 2025-07-29 10:15:23 [ERR] Failed to connect to redis at redis://localhost:6379: connection refused
+// 2025-07-29 10:15:23 [INF] Cache hit rate: 85.6%, Items: 1542

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -301,8 +301,8 @@ func isValidPropertyName(name string) bool {
 				return false
 			}
 		} else {
-			// Allow letters, digits, underscores, and hyphens (for Go template compatibility)
-			if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-' {
+			// Allow letters, digits, underscores, hyphens, and dots (for OTEL compatibility)
+			if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-' && r != '.' {
 				return false
 			}
 		}

--- a/internal/parser/parser_dots_test.go
+++ b/internal/parser/parser_dots_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -268,13 +269,9 @@ func TestValidateTemplateWithDots(t *testing.T) {
 				t.Errorf("ValidateTemplate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if err != nil && tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+			if err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
 				t.Errorf("ValidateTemplate() error = %v, want error containing %v", err, tt.errMsg)
 			}
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && s[:len(substr)] == substr || len(s) > len(substr) && contains(s[1:], substr)
 }

--- a/internal/parser/parser_dots_test.go
+++ b/internal/parser/parser_dots_test.go
@@ -1,0 +1,280 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseWithDottedPropertyNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     string
+		wantProps    []string
+		wantTokens   int
+		wantErr      bool
+		description  string
+	}{
+		{
+			name:        "simple dotted property",
+			template:    "HTTP request {http.method} to {http.url}",
+			wantProps:   []string{"http.method", "http.url"},
+			wantTokens:  4, // "HTTP request ", {http.method}, " to ", {http.url}
+			description: "Should parse OTEL-style dotted properties",
+		},
+		{
+			name:        "multiple dots in property",
+			template:    "Database {db.system.version} query took {db.query.duration.ms}ms",
+			wantProps:   []string{"db.system.version", "db.query.duration.ms"},
+			wantTokens:  5,
+			description: "Should handle multiple dots in property names",
+		},
+		{
+			name:        "dots with destructuring",
+			template:    "User {@user.profile} made request {$http.status.code}",
+			wantProps:   []string{"user.profile", "http.status.code"},
+			wantTokens:  4, // "User ", {@user.profile}, " made request ", {$http.status.code}
+			description: "Should handle dots with destructuring hints",
+		},
+		{
+			name:        "dots with format specifiers",
+			template:    "Duration: {http.duration.ms:F2}ms, Code: {http.status.code:000}",
+			wantProps:   []string{"http.duration.ms", "http.status.code"},
+			wantTokens:  4, // "Duration: ", {http.duration.ms:F2}, "ms, Code: ", {http.status.code:000}
+			description: "Should handle dots with format specifiers",
+		},
+		{
+			name:        "dots with alignment",
+			template:    "Method: {http.method,10} Status: {http.status.code,-5}",
+			wantProps:   []string{"http.method", "http.status.code"},
+			wantTokens:  4, // "Method: ", {http.method,10}, " Status: ", {http.status.code,-5}
+			description: "Should handle dots with alignment",
+		},
+		{
+			name:        "dots with both alignment and format",
+			template:    "Duration: {http.duration.ms,8:F2}ms",
+			wantProps:   []string{"http.duration.ms"},
+			wantTokens:  3,
+			description: "Should handle dots with both alignment and format",
+		},
+		{
+			name:        "Go template syntax with dots",
+			template:    "User {{.user.name}} logged in from {{.client.ip}}",
+			wantProps:   []string{"user.name", "client.ip"},
+			wantTokens:  4, // "User ", {{.user.name}}, " logged in from ", {{.client.ip}}
+			description: "Should handle Go template syntax with dotted properties",
+		},
+		{
+			name:        "Go template with destructuring and dots",
+			template:    "Profile: {{@.user.profile.data}}",
+			wantProps:   []string{"user.profile.data"},
+			wantTokens:  2,
+			description: "Should handle Go template with destructuring and dots",
+		},
+		{
+			name:        "mixed regular and dotted properties",
+			template:    "User {UserId} made {http.method} request to {http.url}",
+			wantProps:   []string{"UserId", "http.method", "http.url"},
+			wantTokens:  6, // "User ", {UserId}, " made ", {http.method}, " request to ", {http.url}
+			description: "Should handle mix of regular and dotted properties",
+		},
+		{
+			name:        "property starting with dot is invalid",
+			template:    "Invalid {.http.method}",
+			wantProps:   []string{".http.method"},
+			wantTokens:  2, // "Invalid ", {.http.method}
+			description: "Property starting with dot should be treated as-is",
+		},
+		{
+			name:        "property ending with dot",
+			template:    "Property {http.method.} value",
+			wantProps:   []string{"http.method."},
+			wantTokens:  3,
+			description: "Property ending with dot is valid",
+		},
+		{
+			name:        "consecutive dots",
+			template:    "Property {http..method} value",
+			wantProps:   []string{"http..method"},
+			wantTokens:  3,
+			description: "Consecutive dots are allowed",
+		},
+		{
+			name:        "OTEL standard attributes",
+			template:    "Service {service.name} version {service.version} in {service.namespace}",
+			wantProps:   []string{"service.name", "service.version", "service.namespace"},
+			wantTokens:  6, // "Service ", {service.name}, " version ", {service.version}, " in ", {service.namespace}
+			description: "Should handle standard OTEL service attributes",
+		},
+		{
+			name:        "OTEL HTTP attributes",
+			template:    "{http.method} {http.route} returned {http.response.status_code}",
+			wantProps:   []string{"http.method", "http.route", "http.response.status_code"},
+			wantTokens:  5,
+			description: "Should handle OTEL HTTP semantic conventions",
+		},
+		{
+			name:        "OTEL database attributes",
+			template:    "Query to {db.system} database {db.name} on {db.connection_string}",
+			wantProps:   []string{"db.system", "db.name", "db.connection_string"},
+			wantTokens:  6, // "Query to ", {db.system}, " database ", {db.name}, " on ", {db.connection_string}
+			description: "Should handle OTEL database attributes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt, err := Parse(tt.template)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			// Check token count
+			if len(mt.Tokens) != tt.wantTokens {
+				t.Errorf("Parse() got %d tokens, want %d", len(mt.Tokens), tt.wantTokens)
+			}
+
+			// Extract and check property names
+			gotProps := ExtractPropertyNames(tt.template)
+			if len(gotProps) != len(tt.wantProps) {
+				t.Errorf("Parse() got properties %v, want %v", gotProps, tt.wantProps)
+				return
+			}
+
+			// Check each property
+			for i, want := range tt.wantProps {
+				if i >= len(gotProps) || gotProps[i] != want {
+					t.Errorf("Parse() property[%d] = %v, want %v", i, gotProps[i], want)
+				}
+			}
+
+			// Verify property tokens have correct names
+			propIndex := 0
+			for _, token := range mt.Tokens {
+				if prop, ok := token.(*PropertyToken); ok {
+					if propIndex >= len(tt.wantProps) {
+						t.Errorf("Parse() found extra property token: %v", prop.PropertyName)
+						continue
+					}
+					if prop.PropertyName != tt.wantProps[propIndex] {
+						t.Errorf("Parse() property token = %v, want %v", prop.PropertyName, tt.wantProps[propIndex])
+					}
+					propIndex++
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidPropertyNameWithDots(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+	}{
+		// Valid cases with dots
+		{"simple dot", "http.method", true},
+		{"multiple dots", "http.request.duration.ms", true},
+		{"underscore and dot", "http_request.method", true},
+		{"hyphen and dot", "http-request.method", true},
+		{"mixed separators", "http_request.status-code", true},
+		
+		// Edge cases that are valid
+		{"ending with dot", "http.method.", true},
+		{"consecutive dots", "http..method", true},
+		{"dot after underscore", "http_.method", true},
+		{"dot after hyphen", "http-.method", true},
+		
+		// Invalid cases
+		{"empty string", "", false},
+		{"starts with dot", ".method", false},
+		{"starts with number", "123.method", false},
+		{"starts with hyphen", "-http.method", false},
+		{"contains space", "http .method", false},
+		{"contains special char", "http@method", false},
+		{"just dot", ".", false},
+		{"just dots", "..", false},
+		
+		// Standard valid cases (no dots)
+		{"simple", "UserId", true},
+		{"with underscore", "user_id", true},
+		{"with hyphen", "user-id", true},
+		{"with numbers", "user123", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidPropertyName(tt.input); got != tt.want {
+				t.Errorf("isValidPropertyName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateTemplateWithDots(t *testing.T) {
+	tests := []struct {
+		name    string
+		template string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:     "valid dotted properties",
+			template: "Request {http.method} to {http.url} returned {http.status}",
+			wantErr:  false,
+		},
+		{
+			name:     "dotted property with format",
+			template: "Duration: {http.duration.ms:F2}ms",
+			wantErr:  false,
+		},
+		{
+			name:     "dotted property with destructuring",
+			template: "User {@user.profile.data}",
+			wantErr:  false,
+		},
+		{
+			name:     "empty property name with dot",
+			template: "Invalid {.}",
+			wantErr:  true,
+			errMsg:   "property name cannot be only dots",
+		},
+		{
+			name:     "property starting with number",
+			template: "Invalid {123.method}",
+			wantErr:  true,
+			errMsg:   "property name starts with a number",
+		},
+		{
+			name:     "unclosed dotted property",
+			template: "Unclosed {http.method",
+			wantErr:  true,
+			errMsg:   "unclosed property",
+		},
+		{
+			name:     "dotted property with spaces",
+			template: "Invalid {http. method}",
+			wantErr:  true,
+			errMsg:   "property name contains spaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTemplate(tt.template)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTemplate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+				t.Errorf("ValidateTemplate() error = %v, want error containing %v", err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && s[:len(substr)] == substr || len(s) > len(substr) && contains(s[1:], substr)
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -186,7 +186,7 @@ func TestIsValidPropertyName(t *testing.T) {
 		{"starts with number", "123user", false},
 		{"contains space", "user name", false},
 		{"contains hyphen", "user-id", true}, // Allowed for Go compatibility
-		{"contains dot", "user.id", false},
+		{"contains dot", "user.id", true}, // Allowed for OTEL compatibility
 	}
 	
 	for _, tt := range tests {

--- a/internal/parser/validate.go
+++ b/internal/parser/validate.go
@@ -100,6 +100,18 @@ func validateProperty(prop string) error {
 		return fmt.Errorf("property name contains spaces")
 	}
 
+	// Check if property is just dots with no actual name
+	allDots := true
+	for _, r := range propName {
+		if r != '.' {
+			allDots = false
+			break
+		}
+	}
+	if allDots {
+		return fmt.Errorf("property name cannot be only dots")
+	}
+
 	// Check if starts with number
 	if propName[0] >= '0' && propName[0] <= '9' {
 		return fmt.Errorf("property name starts with a number")

--- a/logger_dots_test.go
+++ b/logger_dots_test.go
@@ -1,0 +1,176 @@
+package mtlog
+
+import (
+	"testing"
+	"github.com/willibrandon/mtlog/sinks"
+	"github.com/willibrandon/mtlog/internal/parser"
+)
+
+func TestLoggerWithDottedPropertyNames(t *testing.T) {
+	sink := sinks.NewMemorySink()
+	logger := New(WithSink(sink))
+
+	// Test basic OTEL-style properties
+	logger.Information("HTTP request {http.method} to {http.url} took {http.duration.ms}ms", "GET", "/api/users", 123.45)
+	
+	if len(sink.Events()) != 1 {
+		t.Fatalf("Expected 1 event, got %d", len(sink.Events()))
+	}
+	
+	event := sink.Events()[0]
+	
+	// Check properties
+	if method, ok := event.Properties["http.method"].(string); !ok || method != "GET" {
+		t.Errorf("Expected http.method='GET', got %v", event.Properties["http.method"])
+	}
+	
+	if url, ok := event.Properties["http.url"].(string); !ok || url != "/api/users" {
+		t.Errorf("Expected http.url='/api/users', got %v", event.Properties["http.url"])
+	}
+	
+	if duration, ok := event.Properties["http.duration.ms"].(float64); !ok || duration != 123.45 {
+		t.Errorf("Expected http.duration.ms=123.45, got %v", event.Properties["http.duration.ms"])
+	}
+	
+	// Test rendered message by parsing and rendering
+	mt, err := parser.Parse(event.MessageTemplate)
+	if err != nil {
+		t.Fatalf("Failed to parse message template: %v", err)
+	}
+	renderedMsg := mt.Render(event.Properties)
+	expectedMsg := "HTTP request GET to /api/users took 123.45ms"
+	if renderedMsg != expectedMsg {
+		t.Errorf("Expected message '%s', got '%s'", expectedMsg, renderedMsg)
+	}
+}
+
+func TestLoggerWithComplexDottedProperties(t *testing.T) {
+	sink := sinks.NewMemorySink()
+	logger := New(WithSink(sink))
+
+	// Test various OTEL semantic conventions
+	logger.Information("Service {service.name} version {service.version} in {service.namespace}", "api-gateway", "2.1.0", "production")
+	logger.Information("Database {db.system} operation {db.operation} on {db.name}", "postgresql", "SELECT", "users")
+	logger.Information("Span {trace.span_id} with parent {trace.parent_id}", "abc123", "parent456")
+	
+	if len(sink.Events()) != 3 {
+		t.Fatalf("Expected 3 events, got %d", len(sink.Events()))
+	}
+	
+	// Verify service properties
+	serviceEvent := sink.Events()[0]
+	if name, ok := serviceEvent.Properties["service.name"].(string); !ok || name != "api-gateway" {
+		t.Errorf("Expected service.name='api-gateway', got %v", serviceEvent.Properties["service.name"])
+	}
+	
+	// Verify database properties
+	dbEvent := sink.Events()[1]
+	if system, ok := dbEvent.Properties["db.system"].(string); !ok || system != "postgresql" {
+		t.Errorf("Expected db.system='postgresql', got %v", dbEvent.Properties["db.system"])
+	}
+	
+	// Verify trace properties (with underscore in property name)
+	traceEvent := sink.Events()[2]
+	if spanId, ok := traceEvent.Properties["trace.span_id"].(string); !ok || spanId != "abc123" {
+		t.Errorf("Expected trace.span_id='abc123', got %v", traceEvent.Properties["trace.span_id"])
+	}
+}
+
+func TestLoggerWithDottedPropertiesEdgeCases(t *testing.T) {
+	sink := sinks.NewMemorySink()
+	logger := New(WithSink(sink))
+
+	// Test edge cases
+	logger.Information("Property {ends.with.dot.}", "value1")
+	logger.Information("Property {has..consecutive..dots}", "value2")
+	logger.Information("Property {many.levels.of.nesting.here}", "value3")
+	
+	if len(sink.Events()) != 3 {
+		t.Fatalf("Expected 3 events, got %d", len(sink.Events()))
+	}
+	
+	// Check edge case properties
+	if val, ok := sink.Events()[0].Properties["ends.with.dot."].(string); !ok || val != "value1" {
+		t.Errorf("Expected property with trailing dot, got %v", sink.Events()[0].Properties)
+	}
+	
+	if val, ok := sink.Events()[1].Properties["has..consecutive..dots"].(string); !ok || val != "value2" {
+		t.Errorf("Expected property with consecutive dots, got %v", sink.Events()[1].Properties)
+	}
+	
+	if val, ok := sink.Events()[2].Properties["many.levels.of.nesting.here"].(string); !ok || val != "value3" {
+		t.Errorf("Expected property with many dots, got %v", sink.Events()[2].Properties)
+	}
+}
+
+func TestLoggerWithDottedPropertiesFormatting(t *testing.T) {
+	sink := sinks.NewMemorySink()
+	logger := New(WithSink(sink))
+
+	// Test with format specifiers
+	logger.Information("Duration: {http.duration.ms:F2}ms, Status: {http.status.code:000}", 123.456, 200)
+	
+	event := sink.Events()[0]
+	
+	// Check the formatted message by parsing and rendering
+	mt, err := parser.Parse(event.MessageTemplate)
+	if err != nil {
+		t.Fatalf("Failed to parse message template: %v", err)
+	}
+	renderedMsg := mt.Render(event.Properties)
+	expectedMsg := "Duration: 123.46ms, Status: 200"
+	if renderedMsg != expectedMsg {
+		t.Errorf("Expected message '%s', got '%s'", expectedMsg, renderedMsg)
+	}
+	
+	// Properties should still have original values
+	if duration, ok := event.Properties["http.duration.ms"].(float64); !ok || duration != 123.456 {
+		t.Errorf("Expected http.duration.ms=123.456, got %v", event.Properties["http.duration.ms"])
+	}
+}
+
+func TestLoggerWithMixedPropertyStyles(t *testing.T) {
+	sink := sinks.NewMemorySink()
+	logger := New(WithSink(sink))
+
+	// Mix traditional PascalCase with OTEL-style dotted properties
+	logger.Information("User {UserId} made {http.method} request to {http.url} from {ClientIP}", 
+		123, "POST", "/api/orders", "192.168.1.100")
+	
+	event := sink.Events()[0]
+	
+	// Check both styles work together
+	if userId, ok := event.Properties["UserId"].(int); !ok || userId != 123 {
+		t.Errorf("Expected UserId=123, got %v", event.Properties["UserId"])
+	}
+	
+	if method, ok := event.Properties["http.method"].(string); !ok || method != "POST" {
+		t.Errorf("Expected http.method='POST', got %v", event.Properties["http.method"])
+	}
+	
+	if ip, ok := event.Properties["ClientIP"].(string); !ok || ip != "192.168.1.100" {
+		t.Errorf("Expected ClientIP='192.168.1.100', got %v", event.Properties["ClientIP"])
+	}
+}
+
+func TestContextWithDottedPropertyNames(t *testing.T) {
+	sink := sinks.NewMemorySink()
+	logger := New(WithSink(sink))
+	
+	// Test ForContext with dotted property names
+	contextLogger := logger.ForContext("trace.id", "xyz789").
+		ForContext("http.request_id", "req-123")
+	
+	contextLogger.Information("Processing request")
+	
+	event := sink.Events()[0]
+	
+	// Check context properties with dots
+	if traceId, ok := event.Properties["trace.id"].(string); !ok || traceId != "xyz789" {
+		t.Errorf("Expected trace.id='xyz789', got %v", event.Properties["trace.id"])
+	}
+	
+	if reqId, ok := event.Properties["http.request_id"].(string); !ok || reqId != "req-123" {
+		t.Errorf("Expected http.request_id='req-123', got %v", event.Properties["http.request_id"])
+	}
+}


### PR DESCRIPTION
  - Allow dots in property names like {http.method}, {service.name}
  - Add validation to reject properties that are only dots
  - Update analyzer to skip PascalCase suggestion for dotted names
  - Add comprehensive tests and OTEL example
  - Update documentation with OTEL conventions

  Implements #2

## Description
Add support for OpenTelemetry-style dotted property names in message templates to improve compatibility with OTEL semantic conventions. This allows properties like `{http.method}`, `{service.name}`, and `{trace.span_id}` to be used naturally in log messages.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Documentation update

## Checklist
- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Benchmarks checked (if performance-related)
- [x] Documentation updated (if needed)
- [x] Zero-allocation promise maintained (if applicable)

## Additional notes
This change maintains backward compatibility - existing PascalCase properties continue to work as before. The analyzer has been updated to understand OTEL conventions and won't suggest PascalCase for dotted properties.