### PR TITLE
BREAKING: Rename 'destructuring' to 'capturing' throughout codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OTEL Compatibility** - Support for dots in property names (#2)
+  - Enable OpenTelemetry-style property names like `{http.method}`, `{service.name}`, `{db.system}`
+  - Validation prevents properties that are only dots (e.g., `{.}`, `{..}`)
+  - Analyzer updated to skip PascalCase suggestions for dotted properties
+  - Works with all features: format specifiers, capturing hints, Go template syntax
+  - Example: `log.Information("HTTP {http.method} to {http.url} took {http.duration.ms:F2}ms", "GET", "/api", 123.45)`
+
+### Changed
+- **Breaking: Renamed 'destructuring' to 'capturing'** (#1)
+  - Based on feedback from Nicholas Blumhardt (Serilog creator)
+  - `Destructurer` interface → `Capturer` interface
+  - `TryDestructure` method → `TryCapture` method
+  - `WithDestructuring()` → `WithCapturing()`
+  - `internal/destructure/` → `internal/capture/`
+  - `examples/destructuring/` → `examples/capturing/`
+  - All documentation and analyzer messages updated
+  - This better reflects the operation: capturing structured data from objects
+
 ## [0.5.0] - 2025-07-29
 
 ### Added
@@ -26,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Network sinks (Seq, Elasticsearch, Splunk): connection errors, HTTP failures
   - File/Rolling sinks: permission errors, disk space issues
   - Template validation: unclosed properties, empty names, invalid syntax
-  - Destructuring: panic recovery with type information
+  - Capturing: panic recovery with type information
   - Configuration: unknown types, parse failures, type mismatches
   
 - **Idempotent Close Methods**
@@ -113,7 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Validates format specifiers
   - Suggests property naming conventions (PascalCase)
   - Detects duplicate properties
-  - Suggests destructuring hints for complex types
+  - Suggests capturing hints for complex types
   - Validates error logging patterns
   - Suggests constants for common context keys
   - Configuration flags: `-strict`, `-common-keys`, `-disable`, `-ignore-dynamic-templates`, `-strict-logger-types`, `-downgrade-errors`
@@ -125,7 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Internal Organization**
-  - Moved implementation packages (destructure, enrichers, filters, formatters, parser, handler) to `internal/` directory
+  - Moved implementation packages (capture, enrichers, filters, formatters, parser, handler) to `internal/` directory
   - Public API remains unchanged - all user-facing packages and interfaces are unaffected
   
 ### Fixed
@@ -214,7 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pipeline Components**
   - Rich enrichment with built-in and custom enrichers
   - Advanced filtering including rate limiting and sampling
-  - Type-safe destructuring with caching for performance
+  - Type-safe capturing with caching for performance
   - Dynamic level control with runtime adjustments
   - Configuration from JSON for flexible deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### 2. Pipeline Architecture
 The logging pipeline follows this flow:
 ```
-Message Template Parser → Enrichment → Filtering → Destructuring → Sinks (Output)
+Message Template Parser → Enrichment → Filtering → Capturing → Sinks (Output)
 ```
 
 ### 3. Ecosystem Compatibility
@@ -95,7 +95,7 @@ go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest
 - Format specifier validation
 - Property naming conventions (PascalCase suggestions)
 - Duplicate property detection
-- Destructuring hints for complex types
+- Capturing hints for complex types
 - Error logging pattern validation
 - Context key constant suggestions
 
@@ -127,7 +127,7 @@ mtlog/
 ├── parser/            # Message template parsing with format specifiers
 ├── enrichers/         # Built-in enrichers (machine name, thread ID, etc.)
 ├── filters/           # Level, predicate, sampling, and rate limit filters
-├── destructure/       # Type destructuring with LogValue support
+├── capture/           # Type capturing with LogValue support
 ├── selflog/           # Internal diagnostics for debugging
 ├── sinks/             # Output destinations
 │   ├── async.go       # Async sink wrapper with batching
@@ -191,7 +191,7 @@ GitHub Actions workflow includes:
 - ✓ Property extraction and rendering
 - ✓ Pipeline architecture
 - ✓ Context propagation
-- ✓ Structured destructuring
+- ✓ Structured capturing
 - ✓ LogValue protocol support
 
 ### Sinks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Message Template Parser → Enrichment → Filtering → Capturing → Sinks (Ou
 - `Logger` - Main logging interface with methods like `Information()`, `Error()`, etc.
 - `LogEventEnricher` - Adds contextual properties to log events
 - `LogEventFilter` - Determines which events proceed through pipeline
-- `Destructurer` - Converts complex types to log-appropriate representations
+- `Capturer` - Converts complex types to log-appropriate representations
 - `LogEventSink` - Outputs events to destinations (Console, File, Seq, etc.)
 - `LoggingLevelSwitch` - Dynamic level control for runtime configuration
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mtlog is a high-performance structured logging library for Go, inspired by [Seri
 - **Rich enrichment** with built-in and custom enrichers
 - **Advanced filtering** including rate limiting and sampling
 - **Minimum level overrides** by source context patterns
-- **Type-safe destructuring** with caching for performance
+- **Type-safe capturing** with caching for performance
 - **Dynamic level control** with runtime adjustments
 - **Configuration from JSON** for flexible deployment
 
@@ -71,7 +71,7 @@ func main() {
     userId := 123
     log.Information("User {UserId} logged in", userId)
     
-    // Destructuring complex types
+    // Capturing complex types
     order := Order{ID: 456, Total: 99.95}
     log.Information("Processing {@Order}", order)
 }
@@ -107,8 +107,8 @@ log.Information("Service {service.name} in {service.namespace}", "api", "product
 // Mix both syntaxes as needed
 log.Information("User {UserId} ({{.Username}}) from {IP}", userId, username, ipAddress)
 
-// Destructuring hints:
-// @ - destructure complex types into properties
+// Capturing hints:
+// @ - capture complex types into properties
 log.Information("Order {@Order} created", order)
 
 // $ - force scalar rendering (stringify)
@@ -157,7 +157,7 @@ log := mtlog.New(
 The logging pipeline processes events through distinct stages:
 
 ```
-Message Template Parser → Enrichment → Filtering → Destructuring → Output
+Message Template Parser → Enrichment → Filtering → Capturing → Output
 ```
 
 ### Configuration with Functional Options
@@ -180,9 +180,9 @@ log := mtlog.New(
     mtlog.WithDynamicLevel(levelSwitch), // Runtime level control
     mtlog.WithFilter(customFilter),
     
-    // Destructuring
-    mtlog.WithDestructuring(),          // Enable @ hints
-    mtlog.WithDestructuringDepth(5),    // Max depth
+    // Capturing
+    mtlog.WithCapturing(),          // Enable @ hints
+    mtlog.WithCapturingDepth(5),    // Max depth
 )
 ```
 
@@ -654,7 +654,7 @@ See the [examples](./examples) directory for complete examples:
 - [Type-based logging](./examples/fortype/main.go)
 - [LogContext scoped properties](./examples/logcontext/main.go)
 - [Advanced filtering](./examples/filtering/main.go)
-- [Destructuring](./examples/destructuring/main.go)
+- [Capturing](./examples/capturing/main.go)
 - [LogValue interface](./examples/logvalue/main.go)
 - [Console themes](./examples/themes/main.go)
 - [Output templates](./examples/output-templates/main.go)
@@ -759,7 +759,7 @@ The analyzer detects:
 - Template/argument count mismatches
 - Invalid property names (spaces, starting with numbers)
 - Duplicate properties in templates
-- Missing destructuring hints for complex types
+- Missing capturing hints for complex types
 - Error logging without error values
 
 Example catches:
@@ -818,11 +818,11 @@ log := mtlog.New(
 
 ### Type Registration
 
-Register types for special handling during destructuring:
+Register types for special handling during capturing:
 
 ```go
-destructurer := destructure.NewDefaultDestructurer()
-destructurer.RegisterScalarType(reflect.TypeOf(uuid.UUID{}))
+capturer := capture.NewDefaultCapturer()
+capturer.RegisterScalarType(reflect.TypeOf(uuid.UUID{}))
 ```
 
 ## Documentation

--- a/adapters/logr/README.md
+++ b/adapters/logr/README.md
@@ -34,7 +34,7 @@ logger.Error(err, "failed to update resource", "reason", "conflict")
 - **Full logr Compatibility**: Drop-in replacement for any logr backend
 - **Message Templates**: Leverage mtlog's powerful message template system
 - **Rich Sinks**: Output to Console, Seq, Elasticsearch, Splunk, and more
-- **Pipeline Architecture**: Add enrichers, filters, and destructurers
+- **Pipeline Architecture**: Add enrichers, filters, and capturers
 - **Performance**: Benefit from mtlog's optimized logging pipeline
 
 ## V-Level Mapping

--- a/adapters/logr/logr_sink.go
+++ b/adapters/logr/logr_sink.go
@@ -34,7 +34,7 @@ var _ logr.LogSink = (*LogrSink)(nil)
 //	logrLogger := logr.New(mtlogr.NewLogrSink(mtlogLogger))
 //
 // All log events from logr will be processed through mtlog's pipeline,
-// including enrichment, filtering, destructuring, and output to configured sinks.
+// including enrichment, filtering, capturing, and output to configured sinks.
 func NewLogrSink(logger core.Logger) *LogrSink {
 	return &LogrSink{
 		logger: logger,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,7 +18,7 @@ go test -bench=. -benchmem
 - **Simple String**: Basic string logging without allocations
 - **With Properties**: Logging with structured fields
 - **Template Parsing**: Message template with multiple parameters
-- **Complex Object**: Logging with object destructuring
+- **Complex Object**: Logging with object capturing
 - **Filtered Out**: Performance when log level filters out the message
 - **Console Output**: Performance with formatted console output
 

--- a/benchmarks/benchmark_comparison_test.go
+++ b/benchmarks/benchmark_comparison_test.go
@@ -229,7 +229,7 @@ func BenchmarkComplexObject(b *testing.B) {
 	b.Run("mtlog", func(b *testing.B) {
 		logger := mtlog.New(
 			mtlog.WithSink(&discardSink{}),
-			mtlog.WithDestructuring(),
+			mtlog.WithCapturing(),
 		)
 		b.ResetTimer()
 		b.ReportAllocs()

--- a/cmd/mtlog-analyzer/README.md
+++ b/cmd/mtlog-analyzer/README.md
@@ -9,7 +9,7 @@ A production-ready static analysis tool for mtlog that catches common mistakes a
 - **Format specifier validation** - Validates format specifiers like `{Count:000}` or `{Price:F2}`
 - **Property naming checks** - Warns about empty properties, spaces, or properties starting with numbers
 - **Duplicate property detection** - Catches when the same property appears multiple times
-- **Destructuring hints** - Suggests using `@` prefix for complex types
+- **Capturing hints** - Suggests using `@` prefix for complex types
 - **Error logging patterns** - Warns when using Error level without an actual error
 - **Context key suggestions** - Suggests constants for commonly used context keys
 
@@ -134,7 +134,7 @@ mtlog-analyzer -strict ./...
 mtlog-analyzer -common-keys=user_id,tenant_id,request_id ./...
 
 # Disable specific checks
-mtlog-analyzer -disable=naming,destructuring ./...
+mtlog-analyzer -disable=naming,capturing ./...
 
 # Ignore dynamic template warnings
 mtlog-analyzer -ignore-dynamic-templates ./...
@@ -158,7 +158,7 @@ Available check names for `-disable`:
 - `template` - Template/argument mismatch detection
 - `duplicate` - Duplicate property detection
 - `naming` - Property naming checks (including PascalCase suggestions)
-- `destructuring` - Destructuring hint suggestions
+- `capturing` - Capturing hint suggestions
 - `error` - Error logging pattern checks
 - `context` - Context key suggestions
 

--- a/cmd/mtlog-analyzer/analyzer/analyzer.go
+++ b/cmd/mtlog-analyzer/analyzer/analyzer.go
@@ -5,7 +5,7 @@
 //   - Invalid format specifiers
 //   - Duplicate property names
 //   - Poor property naming conventions
-//   - Missing destructuring hints for complex types
+//   - Missing capturing hints for complex types
 //   - Error logging without error values
 package analyzer
 
@@ -562,8 +562,8 @@ func runWithAllChecks(pass *analysis.Pass, call *ast.CallExpr, cache *templateCa
 	if !config.DisabledChecks["naming"] {
 		checkPropertyNamingWithConfig(pass, call, template, config)
 	}
-	if !config.DisabledChecks["destructuring"] {
-		checkDestructuringUsageWithConfig(pass, call, template, config)
+	if !config.DisabledChecks["capturing"] {
+		checkCapturingUsageWithConfig(pass, call, template, config)
 	}
 	if !config.DisabledChecks["error"] {
 		checkErrorLoggingWithConfig(pass, call, config)
@@ -579,7 +579,7 @@ func checkDuplicatePropertiesWithConfig(pass *analysis.Pass, call *ast.CallExpr,
 	for _, prop := range properties {
 		// Remove format specifier for comparison
 		propName := strings.SplitN(prop, ":", 2)[0]
-		// Remove destructuring hints
+		// Remove capturing hints
 		propName = strings.TrimPrefix(propName, "@")
 		propName = strings.TrimPrefix(propName, "$")
 		
@@ -602,7 +602,7 @@ func checkPropertyNamingWithConfig(pass *analysis.Pass, call *ast.CallExpr, temp
 	for _, prop := range properties {
 		// Remove format specifier
 		propName := strings.SplitN(prop, ":", 2)[0]
-		// Remove destructuring hints
+		// Remove capturing hints
 		originalName := propName
 		propName = strings.TrimPrefix(propName, "@")
 		propName = strings.TrimPrefix(propName, "$")
@@ -672,8 +672,8 @@ func checkPropertyNamingWithConfig(pass *analysis.Pass, call *ast.CallExpr, temp
 }
 
 
-// checkDestructuringUsageWithConfig checks for proper use of @ and $ prefixes
-func checkDestructuringUsageWithConfig(pass *analysis.Pass, call *ast.CallExpr, template string, config *Config) {
+// checkCapturingUsageWithConfig checks for proper use of @ and $ prefixes
+func checkCapturingUsageWithConfig(pass *analysis.Pass, call *ast.CallExpr, template string, config *Config) {
 	if len(call.Args) < 2 {
 		return
 	}
@@ -728,14 +728,14 @@ func checkDestructuringUsageWithConfig(pass *analysis.Pass, call *ast.CallExpr, 
 			// $ is for scalar rendering - make sure it's appropriate
 			if !isBasicType(argType) && !isStringer(argType) {
 				reportDiagnosticWithConfig(pass, arg.Pos(), SeverityWarning, config,
-					"using $ prefix for complex type %s, consider using @ for destructuring", argType)
+					"using $ prefix for complex type %s, consider using @ for capturing", argType)
 			}
 		} else {
 			// No prefix - suggest @ for complex types
 			if !isBasicType(argType) && !isTimeType(argType) && !isStringer(argType) && !isErrorType(argType) {
 				// Suggestion only
 				reportDiagnosticWithConfig(pass, arg.Pos(), SeveritySuggestion, config,
-					"consider using @ prefix for complex type %s to enable destructuring", argType)
+					"consider using @ prefix for complex type %s to enable capturing", argType)
 			}
 		}
 	}

--- a/cmd/mtlog-analyzer/analyzer/testdata/src/dots/dots.go
+++ b/cmd/mtlog-analyzer/analyzer/testdata/src/dots/dots.go
@@ -35,7 +35,7 @@ func testAll() {
 	log.Information("Duration: {http.duration.ms:F2}ms", 123.456)
 	log.Information("Status code: {http.status.code:000}", 200)
 	
-	// Dotted properties with destructuring
+	// Dotted properties with capturing
 	userProfile := struct {
 		Name  string
 		Email string

--- a/cmd/mtlog-analyzer/analyzer/testdata/src/integration/integration.go
+++ b/cmd/mtlog-analyzer/analyzer/testdata/src/integration/integration.go
@@ -61,7 +61,7 @@ func testPropertyNaming() {
 	log.Information("User {userId} logged in", 123) // want "suggestion: consider using PascalCase for property 'userId'"
 }
 
-func testDestructuringUsage() {
+func testCapturingUsage() {
 	type User struct {
 		ID   int
 		Name string

--- a/cmd/mtlog-analyzer/analyzer/testdata/src/integration/integration.go
+++ b/cmd/mtlog-analyzer/analyzer/testdata/src/integration/integration.go
@@ -77,14 +77,14 @@ func testDestructuringUsage() {
 	log.Information("Count is {@Count}", count) // want "warning: using @ prefix for basic type int, consider removing prefix"
 	
 	// Suggestion: complex type without @
-	log.Debug("User {User} logged in", user) // want "suggestion: consider using @ prefix for complex type integration.User to enable destructuring"
+	log.Debug("User {User} logged in", user) // want "suggestion: consider using @ prefix for complex type integration.User to enable capturing"
 	
 	// Valid: @ with complex type
 	log.Information("User {@User} logged in", user)
 	
 	// Slices and maps should suggest @ prefix
-	log.Information("Users: {Users}", users) // want "suggestion: consider using @ prefix for complex type \\[\\]integration.User to enable destructuring"
-	log.Information("User map: {UserMap}", userMap) // want "suggestion: consider using @ prefix for complex type map\\[string\\]integration.User to enable destructuring"
+	log.Information("Users: {Users}", users) // want "suggestion: consider using @ prefix for complex type \\[\\]integration.User to enable capturing"
+	log.Information("User map: {UserMap}", userMap) // want "suggestion: consider using @ prefix for complex type map\\[string\\]integration.User to enable capturing"
 }
 
 func testErrorLogging() {
@@ -149,13 +149,13 @@ func testEverything() {
 	err := fmt.Errorf("something went wrong")
 	log.Error("Failed to process request", err) // Good - has error
 	
-	// Test destructuring suggestions
+	// Test capturing suggestions
 	type User struct {
 		Name string
 		Age  int
 	}
 	user := User{Name: "Alice", Age: 30}
-	log.Information("User logged in: {User}", user) // want "suggestion: consider using @ prefix for complex type integration.User to enable destructuring"
+	log.Information("User logged in: {User}", user) // want "suggestion: consider using @ prefix for complex type integration.User to enable capturing"
 	
 	// Test format specifiers
 	log.Information("Progress: {Percent:P2}", 0.456) // Good

--- a/convenience.go
+++ b/convenience.go
@@ -2,7 +2,7 @@ package mtlog
 
 import (
 	"github.com/willibrandon/mtlog/core"
-	"github.com/willibrandon/mtlog/internal/destructure"
+	"github.com/willibrandon/mtlog/internal/capture"
 	"github.com/willibrandon/mtlog/internal/enrichers"
 	"github.com/willibrandon/mtlog/internal/filters"
 	"github.com/willibrandon/mtlog/sinks"
@@ -224,23 +224,23 @@ func WithMinimumLevelOverrides(defaultLevel core.LogEventLevel, overrides map[st
 	return WithFilter(filters.NewSourceContextLevelFilter(defaultLevel, overrides))
 }
 
-// Destructuring options
+// Capturing options
 
-// WithDestructuring adds the cached destructurer for better performance.
-func WithDestructuring() Option {
-	return WithDestructurer(destructure.NewCachedDestructurer())
+// WithCapturing adds the cached capturer for better performance.
+func WithCapturing() Option {
+	return WithCapturer(capture.NewCachedCapturer())
 }
 
-// WithDestructuringDepth adds destructuring with a specific max depth.
-func WithDestructuringDepth(maxDepth int) Option {
-	d := destructure.NewCachedDestructurer()
-	d.DefaultDestructurer = destructure.NewDestructurer(maxDepth, 1000, 100)
-	return WithDestructurer(d)
+// WithCapturingDepth adds capturing with a specific max depth.
+func WithCapturingDepth(maxDepth int) Option {
+	d := capture.NewCachedCapturer()
+	d.DefaultCapturer = capture.NewCapturer(maxDepth, 1000, 100)
+	return WithCapturer(d)
 }
 
-// WithCustomDestructuring adds a destructurer with custom limits.
-func WithCustomDestructuring(maxDepth, maxStringLength, maxCollectionCount int) Option {
-	return WithDestructurer(destructure.NewDestructurer(maxDepth, maxStringLength, maxCollectionCount))
+// WithCustomCapturing adds a capturer with custom limits.
+func WithCustomCapturing(maxDepth, maxStringLength, maxCollectionCount int) Option {
+	return WithCapturer(capture.NewCapturer(maxDepth, maxStringLength, maxCollectionCount))
 }
 
 // Level convenience options

--- a/core/capturer.go
+++ b/core/capturer.go
@@ -1,0 +1,8 @@
+package core
+
+// Capturer converts complex types to log-appropriate representations.
+type Capturer interface {
+	// TryCapture attempts to capture a value into a log event property.
+	// Returns the property and true if successful, nil and false otherwise.
+	TryCapture(value interface{}, propertyFactory LogEventPropertyFactory) (*LogEventProperty, bool)
+}

--- a/core/destructurer.go
+++ b/core/destructurer.go
@@ -1,8 +1,0 @@
-package core
-
-// Destructurer converts complex types to log-appropriate representations.
-type Destructurer interface {
-	// TryDestructure attempts to destructure a value into a log event property.
-	// Returns the property and true if successful, nil and false otherwise.
-	TryDestructure(value interface{}, propertyFactory LogEventPropertyFactory) (*LogEventProperty, bool)
-}

--- a/core/logvalue.go
+++ b/core/logvalue.go
@@ -2,10 +2,10 @@ package core
 
 // LogValue is an optional interface that types can implement to provide
 // custom log representations. When a type implements this interface,
-// the destructurer will use the returned value instead of using reflection.
+// the capturer will use the returned value instead of using reflection.
 type LogValue interface {
 	// LogValue returns the value to be logged. This can be a simple type
 	// (string, number, bool) or a complex type (struct, map, slice).
-	// The returned value may itself be destructured if it's complex.
+	// The returned value may itself be captured if it's complex.
 	LogValue() interface{}
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -50,7 +50,7 @@ mtlog achieves its goal of zero-allocation logging for simple messages while mai
 | zap | 130.8 ns | 0 | 0 B |
 | **zerolog** | 35.25 ns | 0 | 0 B |
 
-### 5. Complex Object (Struct Destructuring)
+### 5. Complex Object (Struct Capturing)
 | Logger | Time/op | Allocations | Bytes/op |
 |--------|---------|-------------|----------|
 | mtlog | 422.8 ns | 11 | 913 B |
@@ -83,7 +83,7 @@ mtlog achieves its goal of zero-allocation logging for simple messages while mai
 
 ### Areas for Optimization
 1. **Property allocation** - Currently allocates for each property
-2. **Complex objects** - Reflection-based destructuring has overhead
+2. **Complex objects** - Reflection-based capturing has overhead
 3. **Template parsing** - Could benefit from more aggressive caching
 
 ### Design Trade-offs

--- a/docs/generics.md
+++ b/docs/generics.md
@@ -82,7 +82,7 @@ logger.InformationT("Rate: {Rate}", 3.14159)
 logger.InformationT("Name: {Name}", "Alice")
 logger.InformationT("Active: {Active}", true)
 
-// Complex types (with destructuring)
+// Complex types (with capturing)
 user := User{ID: 123, Name: "Bob"}
 logger.InformationT("User created: {@User}", user)
 
@@ -151,9 +151,9 @@ logger.InformationT("Count: {Items:N0}", 1000)
 logger.InformationT("Progress: {Percent:P2}", 0.755)
 ```
 
-### With Destructuring
+### With Capturing
 
-Destructuring hints work with generics:
+Capturing hints work with generics:
 
 ```go
 // Destructure complex types
@@ -393,7 +393,7 @@ func main() {
     logger.DebugT("Processing order {OrderId} for user {UserId} total {Total}",
         orderID, userID, total)
     
-    // Complex type destructuring
+    // Complex type capturing
     order := Order{
         ID:     orderID,
         UserID: userID,

--- a/docs/generics.md
+++ b/docs/generics.md
@@ -156,7 +156,7 @@ logger.InformationT("Progress: {Percent:P2}", 0.755)
 Capturing hints work with generics:
 
 ```go
-// Destructure complex types
+// Capture complex types
 order := Order{ID: "ORD-123", Total: 99.95, Items: 3}
 logger.InformationT("Processing {@Order}", order)
 

--- a/docs/quick-reference.html
+++ b/docs/quick-reference.html
@@ -189,9 +189,9 @@ log.Information("User {{.UserId}} logged in from {{.IP}}", userId, ipAddress)
 log.Information("User {UserId} ({{.Username}}) from {IP}", userId, username, ipAddress)</code></pre>
                         </div>
 
-                        <h3 class="text-xl font-semibold mb-2">Destructuring Hints</h3>
+                        <h3 class="text-xl font-semibold mb-2">Capturing Hints</h3>
                         <div class="bg-gray-800 rounded-lg p-4 mb-4">
-                            <pre><code class="language-go">// @ - destructure complex types
+                            <pre><code class="language-go">// @ - capture complex types
 log.Information("Order {@Order} created", order)
 
 // $ - force scalar rendering

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -59,7 +59,7 @@ logger.Information("User {UserId} ({{.Username}}) logged in", userId, username)
 
 ### Capturing Hints
 ```go
-// @ - destructure complex types
+// @ - capture complex types
 logger.Information("User: {@User}", user)
 
 // $ - force scalar/string rendering

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -57,7 +57,7 @@ logger.Information("User {{.UserId}} logged in", userId)
 logger.Information("User {UserId} ({{.Username}}) logged in", userId, username)
 ```
 
-### Destructuring Hints
+### Capturing Hints
 ```go
 // @ - destructure complex types
 logger.Information("User: {@User}", user)

--- a/docs/template-syntax.md
+++ b/docs/template-syntax.md
@@ -15,7 +15,7 @@ logger.Information("Order {OrderId:000} total: ${Amount:F2}", orderId, amount)
 - Compact and readable
 - Supports format specifiers with `:` separator
 - Supports alignment with `,` separator
-- Compatible with destructuring hints (`@` and `$`)
+- Compatible with capturing hints (`@` and `$`)
 
 ## Go Template Syntax
 
@@ -73,9 +73,9 @@ mtlog.WithFileTemplate("app.log", "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}] {Messag
 // {Level:l}  - Full lowercase: information, warning, error
 ```
 
-## Destructuring Hints
+## Capturing Hints
 
-Both syntaxes support destructuring hints:
+Both syntaxes support capturing hints:
 
 ```go
 // @ - Destructure complex types

--- a/docs/template-syntax.md
+++ b/docs/template-syntax.md
@@ -78,7 +78,7 @@ mtlog.WithFileTemplate("app.log", "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}] {Messag
 Both syntaxes support capturing hints:
 
 ```go
-// @ - Destructure complex types
+// @ - Capture complex types
 logger.Information("Order {@Order} created", order)
 logger.Information("User {{@.User}} updated", user)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,7 +89,7 @@ Example output:
    - Invalid property names: `"Count {123}"`
 
 4. **Panic Recovery**
-   - Destructuring panics (infinite recursion, nil dereference)
+   - Capturing panics (infinite recursion, nil dereference)
    - LogValue implementation panics
    - Worker goroutine panics in async sinks
 
@@ -199,9 +199,9 @@ sink, _ := sinks.NewElasticsearchSink("http://localhost:9200",
    )
    ```
 
-2. **Slow Destructuring**
+2. **Slow Capturing**
    ```go
-   // Limit destructuring depth
+   // Limit capturing depth
    destructurer := destructure.NewDestructurer(
        2,    // Max depth (default: 3)
        100,  // Max string length

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,7 +202,7 @@ sink, _ := sinks.NewElasticsearchSink("http://localhost:9200",
 2. **Slow Capturing**
    ```go
    // Limit capturing depth
-   destructurer := destructure.NewDestructurer(
+   capturer := capture.NewCapturer(
        2,    // Max depth (default: 3)
        100,  // Max string length
        50,   // Max collection items

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -24,7 +24,7 @@ func main() {
 	log.Warning("Warning - user {UserId} has {AttemptCount} failed login attempts", userId, 3)
 	log.Error("Error - failed to process order {OrderId} for user {UserId}", "ORD-789", userId)
 	
-	// Test destructuring hints
+	// Test capturing hints
 	user := map[string]interface{}{
 		"id":    userId,
 		"name":  userName,

--- a/examples/capturing/main.go
+++ b/examples/capturing/main.go
@@ -35,7 +35,7 @@ func main() {
 	// Example 1: Basic destructuring
 	log1 := mtlog.New(
 		mtlog.WithConsoleProperties(),
-		mtlog.WithDestructuring(),
+		mtlog.WithCapturing(),
 	)
 	
 	user := User{
@@ -68,7 +68,7 @@ func main() {
 	// Example 2: Destructuring with limits
 	log2 := mtlog.New(
 		mtlog.WithConsoleProperties(),
-		mtlog.WithCustomDestructuring(2, 50, 5), // Max depth 2, strings truncated at 50 chars, max 5 items in collections
+		mtlog.WithCustomCapturing(2, 50, 5), // Max depth 2, strings truncated at 50 chars, max 5 items in collections
 	)
 	
 	// Create a large dataset
@@ -82,7 +82,7 @@ func main() {
 		Nested: map[string]interface{}{
 			"level1": map[string]interface{}{
 				"level2": map[string]interface{}{
-					"level3": "This won't be fully destructured due to depth limit",
+					"level3": "This won't be fully captured due to depth limit",
 				},
 			},
 		},
@@ -101,7 +101,7 @@ func main() {
 	// Example 4: Destructuring with errors and special types
 	log4 := mtlog.New(
 		mtlog.WithConsoleProperties(),
-		mtlog.WithDestructuring(),
+		mtlog.WithCapturing(),
 	)
 	
 	type Response struct {
@@ -127,7 +127,7 @@ func main() {
 	
 	log4.Information("API response: {@Response}", resp)
 	
-	// Example 5: Circular references (destructurer should handle gracefully)
+	// Example 5: Circular references (capturer should handle gracefully)
 	type Node struct {
 		Value int
 		Next  *Node

--- a/examples/capturing/main.go
+++ b/examples/capturing/main.go
@@ -32,7 +32,7 @@ type Address struct {
 }
 
 func main() {
-	// Example 1: Basic destructuring
+	// Example 1: Basic capturing
 	log1 := mtlog.New(
 		mtlog.WithConsoleProperties(),
 		mtlog.WithCapturing(),
@@ -65,7 +65,7 @@ func main() {
 	
 	log1.Information("User logged in: {@User}", user)
 	
-	// Example 2: Destructuring with limits
+	// Example 2: Capturing with limits
 	log2 := mtlog.New(
 		mtlog.WithConsoleProperties(),
 		mtlog.WithCustomCapturing(2, 50, 5), // Max depth 2, strings truncated at 50 chars, max 5 items in collections
@@ -90,15 +90,15 @@ func main() {
 	
 	log2.Information("Large data: {@Data}", largeData)
 	
-	// Example 3: Without destructuring (default behavior)
+	// Example 3: Without capturing (default behavior)
 	log3 := mtlog.New(
 		mtlog.WithConsoleProperties(),
-		// No destructuring - complex objects will use default Go formatting
+		// No capturing - complex objects will use default Go formatting
 	)
 	
-	log3.Information("User without destructuring: {@User}", user)
+	log3.Information("User without capturing: {@User}", user)
 	
-	// Example 4: Destructuring with errors and special types
+	// Example 4: Capturing with errors and special types
 	log4 := mtlog.New(
 		mtlog.WithConsoleProperties(),
 		mtlog.WithCapturing(),

--- a/examples/generics/main.go
+++ b/examples/generics/main.go
@@ -35,7 +35,7 @@ func main() {
 	// Example 1: Type-safe logger for Orders
 	orderLogger := mtlog.NewTyped[Order](
 		mtlog.WithConsoleProperties(),
-		mtlog.WithDestructuring(),
+		mtlog.WithCapturing(),
 	)
 	
 	order := Order{

--- a/examples/logvalue/main.go
+++ b/examples/logvalue/main.go
@@ -158,7 +158,7 @@ func (e LoggableErrorContext) LogValue() interface{} {
 func main() {
 	log := mtlog.New(
 		mtlog.WithConsoleProperties(),
-		mtlog.WithDestructuring(),
+		mtlog.WithCapturing(),
 	)
 	
 	// Example 1: User with sensitive data

--- a/examples/seq/main.go
+++ b/examples/seq/main.go
@@ -92,7 +92,7 @@ func advancedExample() {
 		),
 		mtlog.WithConsoleProperties(),
 		mtlog.WithEnricher(&customEnricher{}),
-		mtlog.WithDestructuring(),
+		mtlog.WithCapturing(),
 	)
 	
 	// Log some events
@@ -110,7 +110,7 @@ func structuredExample() {
 	log := mtlog.New(
 		mtlog.WithSeq("http://localhost:5341"),
 		mtlog.WithConsoleProperties(),
-		mtlog.WithDestructuring(),
+		mtlog.WithCapturing(),
 		mtlog.WithTimestamp(),
 		mtlog.WithCallersInfo(),
 	)

--- a/internal/capture/benchmark_test.go
+++ b/internal/capture/benchmark_test.go
@@ -1,4 +1,4 @@
-package destructure
+package capture
 
 import (
 	"testing"
@@ -58,8 +58,8 @@ func createBenchUser() BenchUser {
 	}
 }
 
-func BenchmarkDefaultDestructurer(b *testing.B) {
-	d := NewDefaultDestructurer()
+func BenchmarkDefaultCapturer(b *testing.B) {
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	user := createBenchUser()
 	
@@ -67,12 +67,12 @@ func BenchmarkDefaultDestructurer(b *testing.B) {
 	b.ReportAllocs()
 	
 	for i := 0; i < b.N; i++ {
-		d.TryDestructure(user, factory)
+		d.TryCapture(user, factory)
 	}
 }
 
-func BenchmarkCachedDestructurer(b *testing.B) {
-	d := NewCachedDestructurer()
+func BenchmarkCachedCapturer(b *testing.B) {
+	d := NewCachedCapturer()
 	factory := &mockPropertyFactory{}
 	user := createBenchUser()
 	
@@ -80,12 +80,12 @@ func BenchmarkCachedDestructurer(b *testing.B) {
 	b.ReportAllocs()
 	
 	for i := 0; i < b.N; i++ {
-		d.TryDestructure(user, factory)
+		d.TryCapture(user, factory)
 	}
 }
 
-func BenchmarkCachedDestructurerParallel(b *testing.B) {
-	d := NewCachedDestructurer()
+func BenchmarkCachedCapturerParallel(b *testing.B) {
+	d := NewCachedCapturer()
 	factory := &mockPropertyFactory{}
 	
 	b.ResetTimer()
@@ -94,13 +94,13 @@ func BenchmarkCachedDestructurerParallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		user := createBenchUser()
 		for pb.Next() {
-			d.TryDestructure(user, factory)
+			d.TryCapture(user, factory)
 		}
 	})
 }
 
 // Benchmark different struct sizes
-func BenchmarkDestructurerBySize(b *testing.B) {
+func BenchmarkCapturerBySize(b *testing.B) {
 	// Small struct
 	type Small struct {
 		ID   int
@@ -163,56 +163,56 @@ func BenchmarkDestructurerBySize(b *testing.B) {
 	factory := &mockPropertyFactory{}
 	
 	b.Run("Small-Default", func(b *testing.B) {
-		d := NewDefaultDestructurer()
+		d := NewDefaultCapturer()
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d.TryDestructure(small, factory)
+			d.TryCapture(small, factory)
 		}
 	})
 	
 	b.Run("Small-Cached", func(b *testing.B) {
-		d := NewCachedDestructurer()
+		d := NewCachedCapturer()
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d.TryDestructure(small, factory)
+			d.TryCapture(small, factory)
 		}
 	})
 	
 	b.Run("Medium-Default", func(b *testing.B) {
-		d := NewDefaultDestructurer()
+		d := NewDefaultCapturer()
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d.TryDestructure(medium, factory)
+			d.TryCapture(medium, factory)
 		}
 	})
 	
 	b.Run("Medium-Cached", func(b *testing.B) {
-		d := NewCachedDestructurer()
+		d := NewCachedCapturer()
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d.TryDestructure(medium, factory)
+			d.TryCapture(medium, factory)
 		}
 	})
 	
 	b.Run("Large-Default", func(b *testing.B) {
-		d := NewDefaultDestructurer()
+		d := NewDefaultCapturer()
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d.TryDestructure(large, factory)
+			d.TryCapture(large, factory)
 		}
 	})
 	
 	b.Run("Large-Cached", func(b *testing.B) {
-		d := NewCachedDestructurer()
+		d := NewCachedCapturer()
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d.TryDestructure(large, factory)
+			d.TryCapture(large, factory)
 		}
 	})
 }

--- a/internal/capture/cache.go
+++ b/internal/capture/cache.go
@@ -251,7 +251,7 @@ func (d *CachedCapturer) capture(value interface{}, depth int) interface{} {
 			return formatTime(value)
 		}
 		
-		// Use cached destructuring for structs
+		// Use cached capturing for structs
 		return d.captureStructCached(v, depth)
 		
 	case reflect.Func, reflect.Chan:

--- a/internal/capture/cache.go
+++ b/internal/capture/cache.go
@@ -1,4 +1,4 @@
-package destructure
+package capture
 
 import (
 	"fmt"
@@ -115,40 +115,40 @@ func (tc *typeCache) createDescriptor(t reflect.Type) *typeDescriptor {
 // Global type cache instance
 var globalTypeCache = newTypeCache()
 
-// CachedDestructurer is a destructurer that caches type information.
-type CachedDestructurer struct {
-	*DefaultDestructurer
+// CachedCapturer is a capturer that caches type information.
+type CachedCapturer struct {
+	*DefaultCapturer
 	typeCache *typeCache
 }
 
-// NewCachedDestructurer creates a new cached destructurer.
-func NewCachedDestructurer() *CachedDestructurer {
-	return &CachedDestructurer{
-		DefaultDestructurer: NewDefaultDestructurer(),
+// NewCachedCapturer creates a new cached capturer.
+func NewCachedCapturer() *CachedCapturer {
+	return &CachedCapturer{
+		DefaultCapturer: NewDefaultCapturer(),
 		typeCache:          globalTypeCache,
 	}
 }
 
-// TryDestructure attempts to destructure a value using cached type information.
-func (d *CachedDestructurer) TryDestructure(value interface{}, propertyFactory core.LogEventPropertyFactory) (*core.LogEventProperty, bool) {
+// TryCapture attempts to capture a value using cached type information.
+func (d *CachedCapturer) TryCapture(value interface{}, propertyFactory core.LogEventPropertyFactory) (*core.LogEventProperty, bool) {
 	if value == nil {
 		return propertyFactory.CreateProperty("", nil), true
 	}
 	
 	// Check if the value implements LogValue interface
 	if lv, ok := value.(core.LogValue); ok {
-		// Recursively destructure the LogValue result
+		// Recursively capture the LogValue result
 		logValue := lv.LogValue()
-		destructured := d.destructure(logValue, 0)
-		return propertyFactory.CreateProperty("", destructured), true
+		captured := d.capture(logValue, 0)
+		return propertyFactory.CreateProperty("", captured), true
 	}
 	
-	destructured := d.destructure(value, 0)
-	return propertyFactory.CreateProperty("", destructured), true
+	captured := d.capture(value, 0)
+	return propertyFactory.CreateProperty("", captured), true
 }
 
-// destructureStructCached destructures a struct using cached type information.
-func (d *CachedDestructurer) destructureStructCached(v reflect.Value, depth int) interface{} {
+// captureStructCached captures a struct using cached type information.
+func (d *CachedCapturer) captureStructCached(v reflect.Value, depth int) interface{} {
 	t := v.Type()
 	desc := d.typeCache.getOrCreate(t)
 	
@@ -156,14 +156,14 @@ func (d *CachedDestructurer) destructureStructCached(v reflect.Value, depth int)
 	
 	for _, field := range desc.Fields {
 		fieldValue := v.Field(field.Index)
-		result[field.Name] = d.destructure(fieldValue.Interface(), depth+1)
+		result[field.Name] = d.capture(fieldValue.Interface(), depth+1)
 	}
 	
 	return result
 }
 
-// destructureSliceCached destructures a slice checking for LogValue on elements.
-func (d *CachedDestructurer) destructureSliceCached(v reflect.Value, depth int) interface{} {
+// captureSliceCached captures a slice checking for LogValue on elements.
+func (d *CachedCapturer) captureSliceCached(v reflect.Value, depth int) interface{} {
 	length := v.Len()
 	if length == 0 {
 		return []interface{}{}
@@ -180,9 +180,9 @@ func (d *CachedDestructurer) destructureSliceCached(v reflect.Value, depth int) 
 		
 		// Check if element implements LogValue
 		if lv, ok := elem.(core.LogValue); ok {
-			result[i] = d.destructure(lv.LogValue(), depth+1)
+			result[i] = d.capture(lv.LogValue(), depth+1)
 		} else {
-			result[i] = d.destructure(elem, depth+1)
+			result[i] = d.capture(elem, depth+1)
 		}
 	}
 	
@@ -194,8 +194,8 @@ func (d *CachedDestructurer) destructureSliceCached(v reflect.Value, depth int) 
 	return result
 }
 
-// Override the destructure method to use caching
-func (d *CachedDestructurer) destructure(value interface{}, depth int) interface{} {
+// Override the capture method to use caching
+func (d *CachedCapturer) capture(value interface{}, depth int) interface{} {
 	if value == nil {
 		return nil
 	}
@@ -226,19 +226,19 @@ func (d *CachedDestructurer) destructure(value interface{}, depth int) interface
 		if v.IsNil() {
 			return nil
 		}
-		return d.destructure(v.Elem().Interface(), depth)
+		return d.capture(v.Elem().Interface(), depth)
 		
 	case reflect.Interface:
 		if v.IsNil() {
 			return nil
 		}
-		return d.destructure(v.Elem().Interface(), depth)
+		return d.capture(v.Elem().Interface(), depth)
 		
 	case reflect.Slice, reflect.Array:
-		return d.destructureSliceCached(v, depth)
+		return d.captureSliceCached(v, depth)
 		
 	case reflect.Map:
-		return d.destructureMap(v, depth)
+		return d.captureMap(v, depth)
 		
 	case reflect.Struct:
 		// Check if it's a known scalar type
@@ -252,7 +252,7 @@ func (d *CachedDestructurer) destructure(value interface{}, depth int) interface
 		}
 		
 		// Use cached destructuring for structs
-		return d.destructureStructCached(v, depth)
+		return d.captureStructCached(v, depth)
 		
 	case reflect.Func, reflect.Chan:
 		return formatType(value)

--- a/internal/capture/capturer_test.go
+++ b/internal/capture/capturer_test.go
@@ -1,4 +1,4 @@
-package destructure
+package capture
 
 import (
 	"testing"
@@ -18,7 +18,7 @@ func (m *mockPropertyFactory) CreateProperty(name string, value interface{}) *co
 }
 
 func TestDestructureBasicTypes(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	tests := []struct {
@@ -36,9 +36,9 @@ func TestDestructureBasicTypes(t *testing.T) {
 	
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prop, ok := d.TryDestructure(tt.input, factory)
+			prop, ok := d.TryCapture(tt.input, factory)
 			if !ok {
-				t.Fatal("TryDestructure failed")
+				t.Fatal("TryCapture failed")
 			}
 			
 			if prop.Value != tt.expected {
@@ -49,12 +49,12 @@ func TestDestructureBasicTypes(t *testing.T) {
 }
 
 func TestDestructureSlice(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	// Test normal slice
 	slice := []int{1, 2, 3, 4, 5}
-	prop, _ := d.TryDestructure(slice, factory)
+	prop, _ := d.TryCapture(slice, factory)
 	
 	result, ok := prop.Value.([]interface{})
 	if !ok {
@@ -67,7 +67,7 @@ func TestDestructureSlice(t *testing.T) {
 	
 	// Test large slice (should be truncated)
 	largeSlice := make([]int, 200)
-	prop2, _ := d.TryDestructure(largeSlice, factory)
+	prop2, _ := d.TryCapture(largeSlice, factory)
 	
 	result2, ok := prop2.Value.([]interface{})
 	if !ok {
@@ -86,7 +86,7 @@ func TestDestructureSlice(t *testing.T) {
 }
 
 func TestDestructureMap(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	// Test normal map
@@ -96,7 +96,7 @@ func TestDestructureMap(t *testing.T) {
 		"c": 3,
 	}
 	
-	prop, _ := d.TryDestructure(m, factory)
+	prop, _ := d.TryCapture(m, factory)
 	result, ok := prop.Value.(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected map[string]interface{}, got %T", prop.Value)
@@ -112,7 +112,7 @@ func TestDestructureMap(t *testing.T) {
 }
 
 func TestDestructureStruct(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	type Address struct {
@@ -143,7 +143,7 @@ func TestDestructureStruct(t *testing.T) {
 		Tags: []string{"developer", "team-lead"},
 	}
 	
-	prop, _ := d.TryDestructure(person, factory)
+	prop, _ := d.TryCapture(person, factory)
 	result, ok := prop.Value.(map[string]interface{})
 	if !ok {
 		t.Fatalf("Expected map[string]interface{}, got %T", prop.Value)
@@ -195,7 +195,7 @@ func TestDestructureStruct(t *testing.T) {
 }
 
 func TestDestructureDepthLimit(t *testing.T) {
-	d := NewDestructurer(3, 1000, 100) // Max depth of 3 (to reach the nested structs)
+	d := NewCapturer(3, 1000, 100) // Max depth of 3 (to reach the nested structs)
 	factory := &mockPropertyFactory{}
 	
 	type Nested struct {
@@ -217,7 +217,7 @@ func TestDestructureDepthLimit(t *testing.T) {
 		},
 	}
 	
-	prop, _ := d.TryDestructure(nested, factory)
+	prop, _ := d.TryCapture(nested, factory)
 	result := prop.Value.(map[string]interface{})
 	
 	// Check first level
@@ -249,11 +249,11 @@ func TestDestructureDepthLimit(t *testing.T) {
 }
 
 func TestDestructureTime(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	now := time.Date(2025, 1, 15, 10, 30, 45, 0, time.UTC)
-	prop, _ := d.TryDestructure(now, factory)
+	prop, _ := d.TryCapture(now, factory)
 	
 	// Time should be formatted as RFC3339
 	expected := "2025-01-15T10:30:45Z"
@@ -263,7 +263,7 @@ func TestDestructureTime(t *testing.T) {
 	
 	// Duration should remain as-is (registered as scalar)
 	duration := 5 * time.Minute
-	prop2, _ := d.TryDestructure(duration, factory)
+	prop2, _ := d.TryCapture(duration, factory)
 	
 	if prop2.Value != duration {
 		t.Errorf("Expected duration to remain as-is, got %v", prop2.Value)
@@ -271,12 +271,12 @@ func TestDestructureTime(t *testing.T) {
 }
 
 func TestDestructurePointers(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	// Test nil pointer
 	var nilPtr *int
-	prop, _ := d.TryDestructure(nilPtr, factory)
+	prop, _ := d.TryCapture(nilPtr, factory)
 	if prop.Value != nil {
 		t.Errorf("Expected nil, got %v", prop.Value)
 	}
@@ -284,7 +284,7 @@ func TestDestructurePointers(t *testing.T) {
 	// Test non-nil pointer
 	val := 42
 	ptr := &val
-	prop2, _ := d.TryDestructure(ptr, factory)
+	prop2, _ := d.TryCapture(ptr, factory)
 	if prop2.Value != 42 {
 		t.Errorf("Expected 42, got %v", prop2.Value)
 	}

--- a/internal/capture/capturer_test.go
+++ b/internal/capture/capturer_test.go
@@ -17,7 +17,7 @@ func (m *mockPropertyFactory) CreateProperty(name string, value interface{}) *co
 	}
 }
 
-func TestDestructureBasicTypes(t *testing.T) {
+func TestCaptureBasicTypes(t *testing.T) {
 	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
@@ -48,7 +48,7 @@ func TestDestructureBasicTypes(t *testing.T) {
 	}
 }
 
-func TestDestructureSlice(t *testing.T) {
+func TestCaptureSlice(t *testing.T) {
 	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
@@ -85,7 +85,7 @@ func TestDestructureSlice(t *testing.T) {
 	}
 }
 
-func TestDestructureMap(t *testing.T) {
+func TestCaptureMap(t *testing.T) {
 	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
@@ -111,7 +111,7 @@ func TestDestructureMap(t *testing.T) {
 	}
 }
 
-func TestDestructureStruct(t *testing.T) {
+func TestCaptureStruct(t *testing.T) {
 	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
@@ -194,7 +194,7 @@ func TestDestructureStruct(t *testing.T) {
 	}
 }
 
-func TestDestructureDepthLimit(t *testing.T) {
+func TestCaptureDepthLimit(t *testing.T) {
 	d := NewCapturer(3, 1000, 100) // Max depth of 3 (to reach the nested structs)
 	factory := &mockPropertyFactory{}
 	
@@ -248,7 +248,7 @@ func TestDestructureDepthLimit(t *testing.T) {
 	}
 }
 
-func TestDestructureTime(t *testing.T) {
+func TestCaptureTime(t *testing.T) {
 	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
@@ -270,7 +270,7 @@ func TestDestructureTime(t *testing.T) {
 	}
 }
 
-func TestDestructurePointers(t *testing.T) {
+func TestCapturePointers(t *testing.T) {
 	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	

--- a/internal/capture/logvalue_test.go
+++ b/internal/capture/logvalue_test.go
@@ -141,7 +141,7 @@ func TestLogValue(t *testing.T) {
 		
 		prop, _ := d.TryCapture(card, factory)
 		
-		// The result should be a struct (map after destructuring)
+		// The result should be a struct (map after capturing)
 		result, ok := prop.Value.(map[string]interface{})
 		if !ok {
 			t.Fatalf("Expected map[string]interface{}, got %T", prop.Value)

--- a/internal/capture/logvalue_test.go
+++ b/internal/capture/logvalue_test.go
@@ -1,4 +1,4 @@
-package destructure
+package capture
 
 import (
 	"testing"
@@ -92,7 +92,7 @@ func (r APIResponse) LogValue() interface{} {
 }
 
 func TestLogValue(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	t.Run("User with sensitive data", func(t *testing.T) {
@@ -103,9 +103,9 @@ func TestLogValue(t *testing.T) {
 			Email:    "alice@example.com",
 		}
 		
-		prop, ok := d.TryDestructure(user, factory)
+		prop, ok := d.TryCapture(user, factory)
 		if !ok {
-			t.Fatal("TryDestructure failed")
+			t.Fatal("TryCapture failed")
 		}
 		
 		result, ok := prop.Value.(map[string]interface{})
@@ -139,7 +139,7 @@ func TestLogValue(t *testing.T) {
 			CVV:    "123",
 		}
 		
-		prop, _ := d.TryDestructure(card, factory)
+		prop, _ := d.TryCapture(card, factory)
 		
 		// The result should be a struct (map after destructuring)
 		result, ok := prop.Value.(map[string]interface{})
@@ -170,7 +170,7 @@ func TestLogValue(t *testing.T) {
 			},
 		}
 		
-		prop, _ := d.TryDestructure(resp, factory)
+		prop, _ := d.TryCapture(resp, factory)
 		result := prop.Value.(map[string]interface{})
 		
 		// Check body is truncated
@@ -198,11 +198,11 @@ func TestLogValue(t *testing.T) {
 	})
 }
 
-func TestLogValueWithCachedDestructurer(t *testing.T) {
-	d := NewCachedDestructurer()
+func TestLogValueWithCachedCapturer(t *testing.T) {
+	d := NewCachedCapturer()
 	factory := &mockPropertyFactory{}
 	
-	// Test that LogValue works with cached destructurer too
+	// Test that LogValue works with cached capturer too
 	user := User{
 		ID:       456,
 		Username: "bob",
@@ -212,7 +212,7 @@ func TestLogValueWithCachedDestructurer(t *testing.T) {
 	
 	// Run twice to ensure caching doesn't interfere
 	for i := 0; i < 2; i++ {
-		prop, _ := d.TryDestructure(user, factory)
+		prop, _ := d.TryCapture(user, factory)
 		result := prop.Value.(map[string]interface{})
 		
 		if _, exists := result["password"]; exists {
@@ -240,7 +240,7 @@ func (t Team) LogValue() interface{} {
 }
 
 func TestNestedLogValue(t *testing.T) {
-	d := NewDefaultDestructurer()
+	d := NewDefaultCapturer()
 	factory := &mockPropertyFactory{}
 	
 	team := Team{
@@ -251,7 +251,7 @@ func TestNestedLogValue(t *testing.T) {
 		},
 	}
 	
-	prop, _ := d.TryDestructure(team, factory)
+	prop, _ := d.TryCapture(team, factory)
 	result := prop.Value.(map[string]interface{})
 	
 	if result["name"] != "Development" {
@@ -262,7 +262,7 @@ func TestNestedLogValue(t *testing.T) {
 		t.Errorf("Expected memberCount=2, got %v", result["memberCount"])
 	}
 	
-	// Check that members are destructured using their LogValue
+	// Check that members are captured using their LogValue
 	members := result["members"].([]interface{})
 	for i, member := range members {
 		m := member.(map[string]interface{})

--- a/internal/formatters/clef.go
+++ b/internal/formatters/clef.go
@@ -74,7 +74,7 @@ func (f *CLEFFormatter) renderMessage(event *core.LogEvent) (string, error) {
 				// Extract property name
 				propName := template[i+1 : j]
 				
-				// Remove destructuring hints
+				// Remove capturing hints
 				propName = strings.TrimPrefix(propName, "@")
 				propName = strings.TrimPrefix(propName, "$")
 				

--- a/internal/parser/benchmark_test.go
+++ b/internal/parser/benchmark_test.go
@@ -37,7 +37,7 @@ func BenchmarkParseMultipleProperties(b *testing.B) {
 	}
 }
 
-func BenchmarkParseWithDestructuring(b *testing.B) {
+func BenchmarkParseWithCapturing(b *testing.B) {
 	template := "Processing {@User} with {$Exception} at {Timestamp}"
 	
 	b.ResetTimer()

--- a/internal/parser/format_test.go
+++ b/internal/parser/format_test.go
@@ -49,7 +49,7 @@ func TestParsePropertyWithFormat(t *testing.T) {
 			expectedAlign: 8,
 		},
 		{
-			name:          "With destructuring and format",
+			name:          "With capturing and format",
 			propertyText:  "@User:json",
 			expectedName:  "User",
 			expectedFormat: "json",

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -90,11 +90,11 @@ func Parse(template string) (*MessageTemplate, error) {
 						if propertyContent == "" {
 							// Empty property name - use empty property token
 							tokens = append(tokens, &PropertyToken{
-								PropertyName:  "",
-								Destructuring: Default,
+								PropertyName: "",
+								Capturing:    Default,
 							})
 						} else {
-							// Parse property token (including destructuring hints)
+							// Parse property token (including capturing hints)
 							propToken := parsePropertyToken(propertyContent)
 							tokens = append(tokens, propToken)
 						}
@@ -104,16 +104,16 @@ func Parse(template string) (*MessageTemplate, error) {
 						continue
 					} else if len(content) > 0 && (content[0] == '@' || content[0] == '$') && len(content) > 1 && content[1] == '.' {
 						// Handle {{@.Property}} or {{$.Property}}
-						destructuring := Default
+						capturing := Default
 						if content[0] == '@' {
-							destructuring = Destructure
+							capturing = Capture
 						} else if content[0] == '$' {
-							destructuring = AsScalar
+							capturing = AsScalar
 						}
 						
 						propertyContent := content[2:] // Skip @. or $.
 						propToken := parsePropertyToken(propertyContent)
-						propToken.Destructuring = destructuring
+						propToken.Capturing = capturing
 						tokens = append(tokens, propToken)
 						
 						i = i + 2 + closeIdx + 2 // Skip past }}
@@ -186,19 +186,19 @@ func Parse(template string) (*MessageTemplate, error) {
 
 // parsePropertyToken parses the content of a property token.
 func parsePropertyToken(content string) *PropertyToken {
-	destructuring := Default
+	capturing := Default
 	propertyName := content
 	format := ""
 	alignment := 0
 	
-	// Check for destructuring prefix
+	// Check for capturing prefix
 	if len(content) > 0 {
 		switch content[0] {
 		case '@':
-			destructuring = Destructure
+			capturing = Capture
 			propertyName = content[1:]
 		case '$':
-			destructuring = AsScalar
+			capturing = AsScalar
 			propertyName = content[1:]
 		}
 	}
@@ -247,14 +247,14 @@ func parsePropertyToken(content string) *PropertyToken {
 	if !isValidPropertyName(propertyName) {
 		// Invalid property name - return as-is
 		return &PropertyToken{
-			PropertyName:  content,
-			Destructuring: Default,
+			PropertyName: content,
+			Capturing:    Default,
 		}
 	}
 	
 	return &PropertyToken{
-		PropertyName:  propertyName,
-		Destructuring: destructuring,
+		PropertyName: propertyName,
+		Capturing:    capturing,
 		Format:        format,
 		Alignment:     alignment,
 	}

--- a/internal/parser/parser_dots_test.go
+++ b/internal/parser/parser_dots_test.go
@@ -29,11 +29,11 @@ func TestParseWithDottedPropertyNames(t *testing.T) {
 			description: "Should handle multiple dots in property names",
 		},
 		{
-			name:        "dots with destructuring",
+			name:        "dots with capturing",
 			template:    "User {@user.profile} made request {$http.status.code}",
 			wantProps:   []string{"user.profile", "http.status.code"},
 			wantTokens:  4, // "User ", {@user.profile}, " made request ", {$http.status.code}
-			description: "Should handle dots with destructuring hints",
+			description: "Should handle dots with capturing hints",
 		},
 		{
 			name:        "dots with format specifiers",
@@ -64,11 +64,11 @@ func TestParseWithDottedPropertyNames(t *testing.T) {
 			description: "Should handle Go template syntax with dotted properties",
 		},
 		{
-			name:        "Go template with destructuring and dots",
+			name:        "Go template with capturing and dots",
 			template:    "Profile: {{@.user.profile.data}}",
 			wantProps:   []string{"user.profile.data"},
 			wantTokens:  2,
-			description: "Should handle Go template with destructuring and dots",
+			description: "Should handle Go template with capturing and dots",
 		},
 		{
 			name:        "mixed regular and dotted properties",
@@ -232,7 +232,7 @@ func TestValidateTemplateWithDots(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "dotted property with destructuring",
+			name:     "dotted property with capturing",
 			template: "User {@user.profile.data}",
 			wantErr:  false,
 		},

--- a/internal/parser/parser_fuzz_test.go
+++ b/internal/parser/parser_fuzz_test.go
@@ -51,7 +51,7 @@ func FuzzParseMessageTemplate(f *testing.F) {
 		"{Value:X}",
 		"{Value:E3}",
 		
-		// Destructuring hints
+		// Capturing hints
 		"{@Object}",
 		"{$String}",
 		"{@User:json}",

--- a/internal/parser/parser_go_template_test.go
+++ b/internal/parser/parser_go_template_test.go
@@ -127,16 +127,16 @@ func TestGoTemplateEdgeCases(t *testing.T) {
 	}
 }
 
-func TestGoTemplateDestructuring(t *testing.T) {
+func TestGoTemplateCapturing(t *testing.T) {
 	tests := []struct {
 		name       string
 		template   string
 		properties map[string]interface{}
 		expected   string
-		checkType  string // To verify destructuring hint is parsed
+		checkType  string // To verify capturing hint is parsed
 	}{
 		{
-			name:       "Go template with @ destructuring",
+			name:       "Go template with @ capturing",
 			template:   "User {{@.User}} created",
 			properties: map[string]interface{}{"User": map[string]interface{}{"id": 1, "name": "Alice"}},
 			expected:   "User ",
@@ -158,20 +158,20 @@ func TestGoTemplateDestructuring(t *testing.T) {
 				t.Fatalf("Parse failed: %v", err)
 			}
 
-			// Check destructuring hint was parsed correctly
+			// Check capturing hint was parsed correctly
 			for _, token := range mt.Tokens {
 				if prop, ok := token.(*PropertyToken); ok {
-					if tt.checkType == "capture" && prop.Destructuring != Destructure {
-						t.Errorf("Expected destructuring hint, got %v", prop.Destructuring)
+					if tt.checkType == "capture" && prop.Capturing != Capture {
+						t.Errorf("Expected capturing hint, got %v", prop.Capturing)
 					}
-					if tt.checkType == "scalar" && prop.Destructuring != AsScalar {
-						t.Errorf("Expected scalar hint, got %v", prop.Destructuring)
+					if tt.checkType == "scalar" && prop.Capturing != AsScalar {
+						t.Errorf("Expected scalar hint, got %v", prop.Capturing)
 					}
 				}
 			}
 
 			result := mt.Render(tt.properties)
-			// For destructuring tests, just check that it starts with expected prefix
+			// For capturing tests, just check that it starts with expected prefix
 			if !strings.HasPrefix(result, tt.expected) {
 				t.Errorf("Expected result to start with %q, got %q", tt.expected, result)
 			}

--- a/internal/parser/parser_go_template_test.go
+++ b/internal/parser/parser_go_template_test.go
@@ -140,7 +140,7 @@ func TestGoTemplateDestructuring(t *testing.T) {
 			template:   "User {{@.User}} created",
 			properties: map[string]interface{}{"User": map[string]interface{}{"id": 1, "name": "Alice"}},
 			expected:   "User ",
-			checkType:  "destructure",
+			checkType:  "capture",
 		},
 		{
 			name:       "Go template with $ scalar",
@@ -161,7 +161,7 @@ func TestGoTemplateDestructuring(t *testing.T) {
 			// Check destructuring hint was parsed correctly
 			for _, token := range mt.Tokens {
 				if prop, ok := token.(*PropertyToken); ok {
-					if tt.checkType == "destructure" && prop.Destructuring != Destructure {
+					if tt.checkType == "capture" && prop.Destructuring != Destructure {
 						t.Errorf("Expected destructuring hint, got %v", prop.Destructuring)
 					}
 					if tt.checkType == "scalar" && prop.Destructuring != AsScalar {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 			template: "Hello, {Name}!",
 			want: []MessageTemplateToken{
 				&TextToken{Text: "Hello, "},
-				&PropertyToken{PropertyName: "Name", Destructuring: Default},
+				&PropertyToken{PropertyName: "Name", Capturing: Default},
 				&TextToken{Text: "!"},
 			},
 		},
@@ -38,19 +38,19 @@ func TestParse(t *testing.T) {
 			template: "User {UserId} logged in from {IpAddress}",
 			want: []MessageTemplateToken{
 				&TextToken{Text: "User "},
-				&PropertyToken{PropertyName: "UserId", Destructuring: Default},
+				&PropertyToken{PropertyName: "UserId", Capturing: Default},
 				&TextToken{Text: " logged in from "},
-				&PropertyToken{PropertyName: "IpAddress", Destructuring: Default},
+				&PropertyToken{PropertyName: "IpAddress", Capturing: Default},
 			},
 		},
 		{
-			name:     "destructuring hints",
+			name:     "capturing hints",
 			template: "Processing {@User} with {$Exception}",
 			want: []MessageTemplateToken{
 				&TextToken{Text: "Processing "},
-				&PropertyToken{PropertyName: "User", Destructuring: Destructure},
+				&PropertyToken{PropertyName: "User", Capturing: Capture},
 				&TextToken{Text: " with "},
-				&PropertyToken{PropertyName: "Exception", Destructuring: AsScalar},
+				&PropertyToken{PropertyName: "Exception", Capturing: AsScalar},
 			},
 		},
 		{
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 			template: "Hello {}!",
 			want: []MessageTemplateToken{
 				&TextToken{Text: "Hello "},
-				&PropertyToken{PropertyName: "", Destructuring: Default},
+				&PropertyToken{PropertyName: "", Capturing: Default},
 				&TextToken{Text: "!"},
 			},
 		},
@@ -85,7 +85,7 @@ func TestParse(t *testing.T) {
 			name:     "property at start",
 			template: "{Name} says hello",
 			want: []MessageTemplateToken{
-				&PropertyToken{PropertyName: "Name", Destructuring: Default},
+				&PropertyToken{PropertyName: "Name", Capturing: Default},
 				&TextToken{Text: " says hello"},
 			},
 		},
@@ -94,15 +94,15 @@ func TestParse(t *testing.T) {
 			template: "Hello, {Name}",
 			want: []MessageTemplateToken{
 				&TextToken{Text: "Hello, "},
-				&PropertyToken{PropertyName: "Name", Destructuring: Default},
+				&PropertyToken{PropertyName: "Name", Capturing: Default},
 			},
 		},
 		{
 			name:     "adjacent properties",
 			template: "{First}{Last}",
 			want: []MessageTemplateToken{
-				&PropertyToken{PropertyName: "First", Destructuring: Default},
-				&PropertyToken{PropertyName: "Last", Destructuring: Default},
+				&PropertyToken{PropertyName: "First", Capturing: Default},
+				&PropertyToken{PropertyName: "Last", Capturing: Default},
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func TestExtractPropertyNames(t *testing.T) {
 			want:     []string{"Name"},
 		},
 		{
-			name:     "destructuring hints",
+			name:     "capturing hints",
 			template: "Processing {@User} with {$Exception}",
 			want:     []string{"User", "Exception"},
 		},
@@ -207,7 +207,7 @@ func tokensEqual(a, b MessageTemplateToken) bool {
 	case *PropertyToken:
 		tb, ok := b.(*PropertyToken)
 		return ok && ta.PropertyName == tb.PropertyName && 
-			ta.Destructuring == tb.Destructuring &&
+			ta.Capturing == tb.Capturing &&
 			ta.Format == tb.Format &&
 			ta.Alignment == tb.Alignment
 	default:

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -29,7 +29,7 @@ type PropertyToken struct {
 	// PropertyName is the name of the property.
 	PropertyName string
 	
-	// Destructuring specifies how the property should be destructured.
+	// Destructuring specifies how the property should be captured.
 	Destructuring DestructuringHint
 	
 	// Format specifies the format string, if any.
@@ -55,7 +55,7 @@ func (p *PropertyToken) Render(properties map[string]interface{}) string {
 	return "{" + p.PropertyName + "}"
 }
 
-// DestructuringHint specifies how a property should be destructured.
+// DestructuringHint specifies how a property should be captured.
 type DestructuringHint int
 
 const (

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -29,8 +29,8 @@ type PropertyToken struct {
 	// PropertyName is the name of the property.
 	PropertyName string
 	
-	// Destructuring specifies how the property should be captured.
-	Destructuring DestructuringHint
+	// Capturing specifies how the property should be captured.
+	Capturing CapturingHint
 	
 	// Format specifies the format string, if any.
 	Format string
@@ -55,18 +55,18 @@ func (p *PropertyToken) Render(properties map[string]interface{}) string {
 	return "{" + p.PropertyName + "}"
 }
 
-// DestructuringHint specifies how a property should be captured.
-type DestructuringHint int
+// CapturingHint specifies how a property should be captured.
+type CapturingHint int
 
 const (
-	// Default destructuring uses ToString.
-	Default DestructuringHint = iota
+	// Default capturing uses ToString.
+	Default CapturingHint = iota
 	
 	// Stringify forces string conversion.
 	Stringify
 	
-	// Destructure captures object structure.
-	Destructure
+	// Capture captures object structure.
+	Capture
 	
 	// AsScalar treats as scalar value.
 	AsScalar

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -59,7 +59,7 @@ func (p *PropertyToken) Render(properties map[string]interface{}) string {
 type CapturingHint int
 
 const (
-	// Default capturing uses ToString.
+	// Default capturing uses Go's default string conversion (e.g., fmt.Sprintf("%v", value)).
 	Default CapturingHint = iota
 	
 	// Stringify forces string conversion.

--- a/internal/parser/validate.go
+++ b/internal/parser/validate.go
@@ -87,12 +87,19 @@ func validateProperty(prop string) error {
 	}
 
 	// Remove capturing hints
+	originalProp := propName
 	propName = strings.TrimPrefix(propName, "@")
 	propName = strings.TrimPrefix(propName, "$")
 	propName = strings.TrimSpace(propName)
 
 	if propName == "" {
-		return fmt.Errorf("empty property name after capturing hint")
+		hint := ""
+		if strings.HasPrefix(originalProp, "@") {
+			hint = "@"
+		} else if strings.HasPrefix(originalProp, "$") {
+			hint = "$"
+		}
+		return fmt.Errorf("empty property name after capturing hint '%s'", hint)
 	}
 
 	// Check for spaces in property name

--- a/internal/parser/validate.go
+++ b/internal/parser/validate.go
@@ -86,13 +86,13 @@ func validateProperty(prop string) error {
 		propName = prop[:idx]
 	}
 
-	// Remove destructuring hints
+	// Remove capturing hints
 	propName = strings.TrimPrefix(propName, "@")
 	propName = strings.TrimPrefix(propName, "$")
 	propName = strings.TrimSpace(propName)
 
 	if propName == "" {
-		return fmt.Errorf("empty property name after destructuring hint")
+		return fmt.Errorf("empty property name after capturing hint")
 	}
 
 	// Check for spaces in property name

--- a/logger.go
+++ b/logger.go
@@ -269,11 +269,11 @@ func (l *logger) extractPropertiesInto(tmpl *parser.MessageTemplate, args []inte
 	// Extract property names from already parsed template
 	propNames := parser.ExtractPropertyNamesFromTemplate(tmpl)
 	
-	// Also check which properties need destructuring
+	// Also check which properties need capturing
 	captureProps := make(map[string]bool)
 	for _, token := range tmpl.Tokens {
 		if prop, ok := token.(*parser.PropertyToken); ok {
-			if prop.Destructuring == parser.Destructure {
+			if prop.Capturing == parser.Capture {
 				captureProps[prop.PropertyName] = true
 			}
 		}
@@ -284,7 +284,7 @@ func (l *logger) extractPropertiesInto(tmpl *parser.MessageTemplate, args []inte
 		if i < len(args) {
 			value := args[i]
 			
-			// Apply destructuring if needed and capturer is available
+			// Apply capturing if needed and capturer is available
 			if captureProps[name] && l.pipeline.capturer != nil {
 				factory := &propertyFactory{}
 				if prop, ok := l.pipeline.capturer.TryCapture(value, factory); ok {

--- a/logger.go
+++ b/logger.go
@@ -54,7 +54,7 @@ func Build(opts ...Option) (*logger, error) {
 	}
 	
 	// Create the pipeline
-	p := newPipeline(cfg.enrichers, cfg.filters, cfg.destructurer, cfg.sinks)
+	p := newPipeline(cfg.enrichers, cfg.filters, cfg.capturer, cfg.sinks)
 	
 	return &logger{
 		minimumLevel: cfg.minimumLevel,
@@ -234,7 +234,7 @@ func (l *logger) WithContext(ctx context.Context) core.Logger {
 		levelSwitch:  l.levelSwitch,
 		enrichers:    make([]core.LogEventEnricher, len(l.pipeline.enrichers)+2),
 		filters:      l.pipeline.filters,
-		destructurer: l.pipeline.destructurer,
+		capturer: l.pipeline.capturer,
 		sinks:        l.pipeline.sinks,
 		properties:   make(map[string]interface{}),
 	}
@@ -254,7 +254,7 @@ func (l *logger) WithContext(ctx context.Context) core.Logger {
 	l.mu.RUnlock()
 	
 	// Create new pipeline
-	p := newPipeline(newConfig.enrichers, newConfig.filters, newConfig.destructurer, newConfig.sinks)
+	p := newPipeline(newConfig.enrichers, newConfig.filters, newConfig.capturer, newConfig.sinks)
 	
 	return &logger{
 		minimumLevel: l.minimumLevel,
@@ -270,11 +270,11 @@ func (l *logger) extractPropertiesInto(tmpl *parser.MessageTemplate, args []inte
 	propNames := parser.ExtractPropertyNamesFromTemplate(tmpl)
 	
 	// Also check which properties need destructuring
-	destructureProps := make(map[string]bool)
+	captureProps := make(map[string]bool)
 	for _, token := range tmpl.Tokens {
 		if prop, ok := token.(*parser.PropertyToken); ok {
 			if prop.Destructuring == parser.Destructure {
-				destructureProps[prop.PropertyName] = true
+				captureProps[prop.PropertyName] = true
 			}
 		}
 	}
@@ -284,10 +284,10 @@ func (l *logger) extractPropertiesInto(tmpl *parser.MessageTemplate, args []inte
 		if i < len(args) {
 			value := args[i]
 			
-			// Apply destructuring if needed and destructurer is available
-			if destructureProps[name] && l.pipeline.destructurer != nil {
+			// Apply destructuring if needed and capturer is available
+			if captureProps[name] && l.pipeline.capturer != nil {
 				factory := &propertyFactory{}
-				if prop, ok := l.pipeline.destructurer.TryDestructure(value, factory); ok {
+				if prop, ok := l.pipeline.capturer.TryCapture(value, factory); ok {
 					value = prop.Value
 				}
 			}

--- a/options.go
+++ b/options.go
@@ -10,7 +10,7 @@ type config struct {
 	levelSwitch  *LoggingLevelSwitch
 	enrichers    []core.LogEventEnricher
 	filters      []core.LogEventFilter
-	destructurer core.Destructurer
+	capturer core.Capturer
 	sinks        []core.LogEventSink
 	properties   map[string]interface{}
 	err          error // First error encountered during configuration
@@ -48,10 +48,10 @@ func WithFilter(filter core.LogEventFilter) Option {
 	}
 }
 
-// WithDestructurer sets the destructurer for the pipeline.
-func WithDestructurer(destructurer core.Destructurer) Option {
+// WithCapturer sets the capturer for the pipeline.
+func WithCapturer(capturer core.Capturer) Option {
 	return func(c *config) {
-		c.destructurer = destructurer
+		c.capturer = capturer
 	}
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -39,7 +39,7 @@ func (p *pipeline) process(event *core.LogEvent, factory core.LogEventPropertyFa
 		}
 	}
 	
-	// Stage 3: Destructuring - handled during property extraction for @ hints
+	// Stage 3: Capturing - handled during property extraction for @ hints
 	// The capturer is made available to the logger but not applied here
 	
 	// Stage 4: Output - send to sinks
@@ -50,7 +50,7 @@ func (p *pipeline) process(event *core.LogEvent, factory core.LogEventPropertyFa
 
 // processSimple handles the fast path for simple string messages.
 func (p *pipeline) processSimple(timestamp time.Time, level core.LogEventLevel, message string) {
-	// Fast path bypasses enrichment, filtering, and destructuring
+	// Fast path bypasses enrichment, filtering, and capturing
 	for _, sink := range p.sinks {
 		if simpleSink, ok := sink.(core.SimpleSink); ok {
 			simpleSink.EmitSimple(timestamp, level, message)

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,16 +11,16 @@ import (
 type pipeline struct {
 	enrichers    []core.LogEventEnricher
 	filters      []core.LogEventFilter
-	destructurer core.Destructurer
+	capturer core.Capturer
 	sinks        []core.LogEventSink
 }
 
 // newPipeline creates a new pipeline with the given stages.
-func newPipeline(enrichers []core.LogEventEnricher, filters []core.LogEventFilter, destructurer core.Destructurer, sinks []core.LogEventSink) *pipeline {
+func newPipeline(enrichers []core.LogEventEnricher, filters []core.LogEventFilter, capturer core.Capturer, sinks []core.LogEventSink) *pipeline {
 	return &pipeline{
 		enrichers:    enrichers,
 		filters:      filters,
-		destructurer: destructurer,
+		capturer: capturer,
 		sinks:        sinks,
 	}
 }
@@ -40,7 +40,7 @@ func (p *pipeline) process(event *core.LogEvent, factory core.LogEventPropertyFa
 	}
 	
 	// Stage 3: Destructuring - handled during property extraction for @ hints
-	// The destructurer is made available to the logger but not applied here
+	// The capturer is made available to the logger but not applied here
 	
 	// Stage 4: Output - send to sinks
 	for _, sink := range p.sinks {


### PR DESCRIPTION
BREAKING CHANGE: Based on feedback from Nicholas Blumhardt, renamed all destructuring-related APIs to use "capturing" terminology which better reflects the operation of capturing structured data from objects.

  - Rename Destructurer interface to Capturer
  - Rename TryDestructure method to TryCapture
  - Rename WithDestructuring() to WithCapturing()
  - Move internal/destructure/ to internal/capture/
  - Move examples/destructuring/ to examples/capturing/
  - Update all example code to use new API names
  - Update all documentation, tests, and analyzer messages
  - Update CHANGELOG with OTEL dots support and capturing rename

Implements #1

  ## Description
This PR implements a major refactoring based on feedback from Nicholas Blumhardt (Serilog creator). The term "destructuring" has been replaced with "capturing" throughout the codebase, as it better describes the operation of capturing structured data from objects into log-friendly representations. This is a breaking change that affects all users who implement the Destructurer interface or use destructuring-related APIs.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation update
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring

## Checklist
- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Benchmarks checked (if performance-related)
- [x] Documentation updated (if needed)
- [x] Zero-allocation promise maintained (if applicable)

## Additional notes
This change aligns mtlog with the terminology used in the broader logging community. While this is a breaking change, it improves clarity and consistency in the API. Users will need to update their code when upgrading to the next version.