### PR TITLE
feat: add smart analyzer detection and auto-install prompts for IDE extensions (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2025-08-06
+
+### Added
+- **IDE Installation UX** - Smart analyzer detection and auto-install prompts (#22)
+  - **VS Code Extension**
+    - Auto-detection in standard Go locations (`$GOBIN`, `$GOPATH/bin`, `~/go/bin`)
+    - One-click installation prompt when analyzer not found
+    - Improved error messages with specific paths and solutions
+    - Automatic path caching for performance
+  
+  - **GoLand Plugin**
+    - Smart path detection following Go's installation precedence
+    - Notification with Install/Settings actions when analyzer not found
+    - Support for platform-specific locations (Windows Apps, /usr/local/go/bin)
+    - findAnalyzerPath() made internal for testing
+
+### Fixed
+- **Build** - Fixed invalid Go version format in go.mod (changed from `1.23.0` to `1.23`)
+- **VS Code Extension** - Added test binaries to .vscodeignore to reduce package size
+
 ## [0.7.3] - 2025-08-05
 
 ### Changed
@@ -350,6 +370,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed hardcoded test tokens from integration tests
 - Added proper environment variable requirements for sensitive data
 
+[0.7.4]: https://github.com/willibrandon/mtlog/releases/tag/v0.7.4
+[0.7.3]: https://github.com/willibrandon/mtlog/releases/tag/v0.7.3
 [0.7.2]: https://github.com/willibrandon/mtlog/releases/tag/v0.7.2
 [0.7.1]: https://github.com/willibrandon/mtlog/releases/tag/v0.7.1
 [0.7.0]: https://github.com/willibrandon/mtlog/releases/tag/v0.7.0

--- a/cmd/mtlog-analyzer/README.md
+++ b/cmd/mtlog-analyzer/README.md
@@ -173,21 +173,47 @@ log.Information("User {userId} logged in", id) // lowercase property name
 
 ## IDE Integration
 
+Both VS Code and GoLand extensions provide real-time validation with automatic analyzer detection and installation:
+
 ### VS Code
 
-For the best experience in Visual Studio Code, install the [mtlog-analyzer extension](https://marketplace.visualstudio.com/items?itemName=mtlog.mtlog-analyzer):
+Install the [mtlog-analyzer extension](https://marketplace.visualstudio.com/items?itemName=mtlog.mtlog-analyzer) from the VS Code Marketplace:
 
-1. Install mtlog-analyzer: `go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest`
-2. Install the extension from VS Code Marketplace (search for "mtlog-analyzer")
-3. Get instant feedback on template errors as you type
+1. Search for "mtlog-analyzer" in Extensions
+2. Click Install
+3. The extension will automatically find mtlog-analyzer or prompt to install it
 
-The extension provides:
+Features:
 - 🔍 Real-time diagnostics with squiggly underlines
 - 🎯 Precise error locations - click to jump to issues
-- 📊 Three severity levels: errors, warnings, and suggestions
+- 💡 Quick fixes for common issues (property names, argument counts)
+- 🚀 Auto-detection in standard Go locations (`$GOBIN`, `$GOPATH/bin`, `~/go/bin`)
+- 📦 One-click installation if not found
 - ⚙️ Configurable analyzer path and flags
 
-For manual setup without the extension, you can configure the Go extension to use mtlog-analyzer:
+### GoLand / IntelliJ IDEA
+
+Install the [mtlog-analyzer plugin](https://plugins.jetbrains.com/plugin/24877-mtlog-analyzer) from JetBrains Marketplace:
+
+1. Go to **Settings → Plugins → Marketplace**
+2. Search for "mtlog-analyzer"
+3. Click Install and restart
+4. The plugin will automatically find mtlog-analyzer or show an install prompt
+
+Features:
+- 🔍 Real-time validation as you type
+- 🎨 Intelligent highlighting by severity
+- 💡 Quick fixes via Alt+Enter
+- 🚀 Auto-detection in standard Go locations
+- 📦 One-click installation notification
+- 📊 Status bar widget for quick access
+- 🔇 Diagnostic suppression support
+
+### Manual IDE Setup
+
+If you prefer not to use the extensions:
+
+**VS Code** (via Go extension):
 ```json
 {
   "go.lintTool": "golangci-lint",
@@ -196,14 +222,12 @@ For manual setup without the extension, you can configure the Go extension to us
 }
 ```
 
-### GoLand / IntelliJ IDEA
-
+**GoLand** (via Go vet settings):
 1. Go to **Settings → Go → Linters → Go vet**
 2. Add custom vet tool:
    - Click **+** to add a new tool
    - Set path to `mtlog-analyzer`
    - Add any desired flags (e.g., `-strict`)
-3. Use **Alt+Enter** on highlighted issues to apply suggested fixes
 
 ### Vim/Neovim (with vim-go)
 
@@ -230,7 +254,7 @@ go vet -vettool=$(which mtlog-analyzer) -json ./... > fixes.json
 
 ## Go Version Compatibility
 
-The analyzer requires Go 1.23.0 or later due to its dependency on newer analysis framework features. The analyzer is built with Go 1.24.1 toolchain for optimal performance.
+The analyzer requires Go 1.23 or later due to its dependency on newer analysis framework features. The analyzer is built with Go 1.24.1 toolchain for optimal performance.
 
 ## Limitations
 

--- a/cmd/mtlog-analyzer/go.mod
+++ b/cmd/mtlog-analyzer/go.mod
@@ -1,6 +1,6 @@
 module github.com/willibrandon/mtlog/cmd/mtlog-analyzer
 
-go 1.23.0
+go 1.23
 
 require golang.org/x/tools v0.35.0
 

--- a/cmd/mtlog-analyzer/package-lock.json
+++ b/cmd/mtlog-analyzer/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "mtlog-analyzer",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/goland-plugin/README.md
+++ b/goland-plugin/README.md
@@ -17,10 +17,7 @@ Real-time validation for mtlog message templates in GoLand and other JetBrains I
 ## Requirements
 
 - GoLand 2024.2 or later (or IntelliJ IDEA Ultimate with Go plugin)
-- mtlog-analyzer installed:
-  ```bash
-  go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest
-  ```
+- mtlog-analyzer (automatically detected or can be installed via notification)
 
 ## Installation
 
@@ -30,7 +27,18 @@ Real-time validation for mtlog message templates in GoLand and other JetBrains I
    - Search for "mtlog-analyzer"
    - Click Install
 
-2. Or download the `.zip` file from releases and install manually
+2. The plugin will automatically find mtlog-analyzer if it's installed. If not found, you'll see a notification with an "Install" button for one-click installation.
+
+### Automatic Detection
+
+The plugin searches for mtlog-analyzer in the following locations (in order):
+1. Configured path in settings
+2. System PATH
+3. Go binary locations:
+   - `$GOBIN`
+   - `$GOPATH/bin`
+   - `~/go/bin` (default Go install location)
+   - Platform-specific locations (e.g., `%LOCALAPPDATA%\Microsoft\WindowsApps` on Windows)
 
 ## Configuration
 
@@ -55,6 +63,24 @@ Use Alt+Enter on any diagnostic to see available quick fixes.
 You can suppress diagnostics using:
 - `//noinspection MTLog` - Suppress on the next line
 - `// MTLOG-IGNORE` - Inline suppression
+
+## Troubleshooting
+
+### "mtlog-analyzer not found"
+
+If the plugin can't find mtlog-analyzer:
+
+1. **Automatic Installation**: Click "Install" in the notification that appears
+2. **Manual Installation**: Run `go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest`
+3. **Custom Location**: Go to Settings → Tools → mtlog-analyzer and specify the full path
+4. **PATH Issues**: Ensure your Go bin directory is in your system PATH
+
+### No diagnostics appearing
+
+- Check the Event Log for analyzer errors
+- Verify mtlog-analyzer works from terminal: `mtlog-analyzer your-file.go`
+- Check Settings → Tools → mtlog-analyzer to ensure the plugin is enabled
+- Try restarting the analyzer from the status bar widget
 
 ## Development
 

--- a/goland-plugin/build.gradle.kts
+++ b/goland-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mtlog"
-version = "0.7.3"
+version = "0.7.4"
 
 repositories {
     mavenCentral()

--- a/goland-plugin/src/main/kotlin/com/mtlog/analyzer/startup/MtlogStartupActivity.kt
+++ b/goland-plugin/src/main/kotlin/com/mtlog/analyzer/startup/MtlogStartupActivity.kt
@@ -24,7 +24,19 @@ class MtlogStartupActivity : ProjectActivity {
         EditorFactory.getInstance().eventMulticaster.addDocumentListener(documentListener, project)
         MtlogLogger.info("Registered MtlogDocumentListener", project)
         
+        // Check if analyzer is available
+        val service = project.service<MtlogProjectService>()
+        if (service.state.enabled) {
+            val analyzerPath = service.findAnalyzerPath()
+            if (analyzerPath == null) {
+                MtlogLogger.warn("mtlog-analyzer not found at startup", project)
+                // Don't show notification at startup - wait until user tries to use it
+            } else {
+                MtlogLogger.info("mtlog-analyzer found at: $analyzerPath", project)
+            }
+        }
+        
         // Log startup message
-        MtlogLogger.info("mtlog-analyzer started", project)
+        MtlogLogger.info("mtlog-analyzer plugin started", project)
     }
 }

--- a/goland-plugin/src/test/kotlin/com/mtlog/analyzer/integration/MtlogProjectServiceIntegrationTest.kt
+++ b/goland-plugin/src/test/kotlin/com/mtlog/analyzer/integration/MtlogProjectServiceIntegrationTest.kt
@@ -210,10 +210,8 @@ class MtlogProjectServiceIntegrationTest : MtlogIntegrationTestBase() {
     }
     
     private fun findAnalyzerPath(): String? {
-        // Use reflection to call the private method
-        val method = service.javaClass.getDeclaredMethod("findAnalyzerPath")
-        method.isAccessible = true
-        return method.invoke(service) as String?
+        // Since findAnalyzerPath is now internal, we can call it directly
+        return service.findAnalyzerPath()
     }
     
     private fun writeFilesToDisk(dir: File) {

--- a/vscode-extension/mtlog-analyzer/.vscodeignore
+++ b/vscode-extension/mtlog-analyzer/.vscodeignore
@@ -11,3 +11,7 @@ vsc-extension-quickstart.md
 node_modules/**
 *.vsix
 package-lock.json
+**/mtlog-analyzer-test
+**/mtlog-analyzer-test.exe
+**/*_test
+**/*.test

--- a/vscode-extension/mtlog-analyzer/README.md
+++ b/vscode-extension/mtlog-analyzer/README.md
@@ -37,16 +37,24 @@ Apply fixes by clicking the light bulb (💡) or pressing `Ctrl+.` (Windows/Linu
 ## Requirements
 
 - Go 1.21 or later
-- [mtlog-analyzer](https://github.com/willibrandon/mtlog/tree/main/cmd/mtlog-analyzer) installed and in PATH
+- [mtlog-analyzer](https://github.com/willibrandon/mtlog/tree/main/cmd/mtlog-analyzer) (automatically detected or can be installed via prompt)
 
 ## Installation
 
-1. Install mtlog-analyzer:
-   ```bash
-   go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest
-   ```
+1. Install this extension from the VS Code Marketplace
 
-2. Install this extension from the VS Code Marketplace
+2. The extension will automatically find mtlog-analyzer if it's installed. If not found, you'll be prompted to install it with one click.
+
+### Automatic Detection
+
+The extension searches for mtlog-analyzer in the following locations (in order):
+1. Configured path in settings
+2. System PATH
+3. Go binary locations:
+   - `$GOBIN`
+   - `$GOPATH/bin`
+   - `~/go/bin` (default Go install location)
+   - Platform-specific locations (e.g., `/usr/local/go/bin` on macOS)
 
 ## Configuration
 
@@ -70,9 +78,20 @@ The extension runs `mtlog-analyzer` when you save Go files, parsing the output a
 ## Troubleshooting
 
 ### "mtlog-analyzer not found"
-- Ensure mtlog-analyzer is installed: `go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest`
-- Add Go bin directory to PATH: `export PATH=$PATH:$(go env GOPATH)/bin`
-- Or specify full path in settings: `"mtlog.analyzerPath": "/full/path/to/mtlog-analyzer"`
+
+If the extension can't find mtlog-analyzer:
+
+1. **Automatic Installation**: Click "Install" when prompted by the extension
+2. **Manual Installation**: Run `go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest`
+3. **PATH Issues**: 
+   - On macOS: If VS Code is launched from Dock/Spotlight, it may not inherit your shell PATH
+   - Solution: Launch VS Code from terminal with `code .` or restart VS Code after installation
+4. **Custom Location**: Specify the full path in settings:
+   ```json
+   {
+     "mtlog.analyzerPath": "/full/path/to/mtlog-analyzer"
+   }
+   ```
 
 ### No diagnostics appearing
 - Check Output panel (View → Output → mtlog-analyzer) for errors

--- a/vscode-extension/mtlog-analyzer/package-lock.json
+++ b/vscode-extension/mtlog-analyzer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mtlog-analyzer",
-  "version": "0.1.0",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mtlog-analyzer",
-      "version": "0.1.0",
+      "version": "0.7.4",
       "dependencies": {
         "glob": "^11.0.3"
       },

--- a/vscode-extension/mtlog-analyzer/package.json
+++ b/vscode-extension/mtlog-analyzer/package.json
@@ -3,7 +3,7 @@
   "displayName": "mtlog-analyzer",
   "description": "Real-time mtlog template validation for Go",
   "icon": "assets/icon.png",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "publisher": "mtlog",
   "repository": {
     "type": "git",

--- a/vscode-extension/mtlog-analyzer/src/extension.ts
+++ b/vscode-extension/mtlog-analyzer/src/extension.ts
@@ -501,9 +501,16 @@ async function analyzeDocument(document: vscode.TextDocument) {
     
     // Not using cache anymore - causes stale diagnostics
     
-    // Get the analyzer path and flags from config
+    // Get the analyzer path using smart detection
+    const analyzerPath = await findAnalyzer();
+    if (!analyzerPath) {
+        VSCodeMtlogLogger.error('Analyzer not found - cannot run analysis', undefined, false);
+        await checkAnalyzerAvailable();
+        return;
+    }
+    
+    // Get flags from config
     const config = vscode.workspace.getConfiguration('mtlog');
-    const analyzerPath = config.get<string>('analyzerPath', 'mtlog-analyzer');
     const analyzerFlags = config.get<string[]>('analyzerFlags', []);
     
     // Add kill switch flags based on configuration
@@ -785,92 +792,215 @@ function countIssuesBySeverity(severity: vscode.DiagnosticSeverity): number {
     return count;
 }
 
-function checkAnalyzerAvailable() {
+// Smart analyzer detection following Go's installation precedence
+async function findAnalyzer(): Promise<string | undefined> {
     const config = vscode.workspace.getConfiguration('mtlog');
-    let analyzerPath = config.get<string>('analyzerPath', 'mtlog-analyzer');
-
-    if (analyzerPath.includes(path.sep) || analyzerPath.includes('/')) {
-        if (fs.existsSync(analyzerPath)) {
-            outputChannel.appendLine(`[${new Date().toLocaleTimeString()}] Analyzer found at ${analyzerPath}`);
-            return;
+    const configuredPath = config.get<string>('analyzerPath');
+    
+    // 1. Check explicit setting first
+    if (configuredPath && configuredPath !== 'mtlog-analyzer') {
+        if (fs.existsSync(configuredPath)) {
+            VSCodeMtlogLogger.debug(`Analyzer found at configured path: ${configuredPath}`);
+            return configuredPath;
+        }
+        VSCodeMtlogLogger.warn(`Configured analyzer path not found: ${configuredPath}`, false);
+    }
+    
+    // 2. Try to find in PATH
+    try {
+        const pathResult = execSync('which mtlog-analyzer', { encoding: 'utf8' }).trim();
+        if (pathResult) {
+            VSCodeMtlogLogger.debug(`Analyzer found in PATH: ${pathResult}`);
+            return pathResult;
+        }
+    } catch (e) {
+        // which command failed, continue searching
+    }
+    
+    // For Windows, try where command
+    if (os.platform() === 'win32') {
+        try {
+            const whereResult = execSync('where mtlog-analyzer', { encoding: 'utf8' }).trim().split('\n')[0];
+            if (whereResult) {
+                VSCodeMtlogLogger.debug(`Analyzer found via where: ${whereResult}`);
+                return whereResult;
+            }
+        } catch (e) {
+            // where command failed, continue searching
         }
     }
-
-    outputChannel.appendLine(`[${new Date().toLocaleTimeString()}] Analyzer not found`);
-    vscode.window.showInformationMessage(
-        'mtlog-analyzer not found. Install it to enable real-time template validation.',
-        'Install Now',
-        'Not Now'
-    ).then(selection => {
-        if (selection === 'Install Now') {
-            installAnalyzer();
+    
+    // 3. Check Go installation locations following Go's precedence
+    const goLocations: string[] = [];
+    const binaryName = os.platform() === 'win32' ? 'mtlog-analyzer.exe' : 'mtlog-analyzer';
+    
+    // Check GOBIN first
+    const gobin = process.env.GOBIN;
+    if (gobin) {
+        goLocations.push(path.join(gobin, binaryName));
+    }
+    
+    // Check GOPATH/bin
+    const gopath = process.env.GOPATH || path.join(os.homedir(), 'go');
+    goLocations.push(path.join(gopath, 'bin', binaryName));
+    
+    // Check default $HOME/go/bin if different from GOPATH
+    const defaultGoPath = path.join(os.homedir(), 'go', 'bin', binaryName);
+    if (!goLocations.includes(defaultGoPath)) {
+        goLocations.push(defaultGoPath);
+    }
+    
+    // Platform-specific locations
+    if (os.platform() === 'darwin') {
+        // Homebrew locations
+        goLocations.push('/usr/local/bin/mtlog-analyzer');
+        goLocations.push('/opt/homebrew/bin/mtlog-analyzer');
+    }
+    
+    // Check each location
+    for (const location of goLocations) {
+        if (fs.existsSync(location)) {
+            VSCodeMtlogLogger.debug(`Analyzer found at: ${location}`);
+            return location;
         }
-    });
+    }
+    
+    // Log all checked locations for debugging
+    VSCodeMtlogLogger.debug(`Analyzer not found. Checked locations:\n${goLocations.join('\n')}`);
+    return undefined;
+}
+
+async function checkAnalyzerAvailable() {
+    const analyzerPath = await findAnalyzer();
+    
+    if (analyzerPath) {
+        // Update the configuration with the found path for performance
+        const config = vscode.workspace.getConfiguration('mtlog');
+        const currentPath = config.get<string>('analyzerPath');
+        if (currentPath === 'mtlog-analyzer') {
+            // Only update if using default value
+            await config.update('analyzerPath', analyzerPath, vscode.ConfigurationTarget.Global);
+            VSCodeMtlogLogger.info(`Updated analyzer path to: ${analyzerPath}`);
+        }
+        return;
+    }
+    
+    // Show detailed error message with specific paths
+    const gopath = process.env.GOPATH || path.join(os.homedir(), 'go');
+    const expectedPath = path.join(gopath, 'bin', os.platform() === 'win32' ? 'mtlog-analyzer.exe' : 'mtlog-analyzer');
+    
+    const message = `mtlog-analyzer not found in PATH or standard Go locations.\n\nExpected location: ${expectedPath}`;
+    
+    const selection = await vscode.window.showErrorMessage(
+        message,
+        'Install Now',
+        'Configure Path',
+        'Dismiss'
+    );
+    
+    if (selection === 'Install Now') {
+        await installAnalyzer();
+    } else if (selection === 'Configure Path') {
+        await vscode.commands.executeCommand('workbench.action.openSettings', 'mtlog.analyzerPath');
+    }
 }
 
 async function installAnalyzer() {
+    // Check if Go is installed first
+    let goInstalled = false;
+    try {
+        execSync('go version', { encoding: 'utf8' });
+        goInstalled = true;
+    } catch (e) {
+        // Go not found
+    }
+    
+    const options = goInstalled 
+        ? ['Install with Go (recommended)', 'Configure Path Manually', 'Cancel']
+        : ['Configure Path Manually', 'Install Go First', 'Cancel'];
+    
     const installMethod = await vscode.window.showQuickPick(
-        ['Install with Go (recommended)', 'Download pre-built binary', 'Cancel'],
-        { placeHolder: 'How would you like to install mtlog-analyzer?' }
+        options,
+        { 
+            placeHolder: goInstalled 
+                ? 'How would you like to install mtlog-analyzer?' 
+                : 'Go is not installed. Please install Go first or configure the path manually.'
+        }
     );
     
     if (!installMethod || installMethod === 'Cancel') {
         return;
     }
     
-    if (installMethod === 'Install with Go (recommended)') {
-        const terminal = vscode.window.createTerminal('Install mtlog-analyzer');
-        terminal.show();
-        terminal.sendText('go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest');
-        
-        // Show message about what's happening
+    if (installMethod === 'Install Go First') {
+        vscode.env.openExternal(vscode.Uri.parse('https://go.dev/doc/install'));
+        return;
+    }
+    
+    if (installMethod === 'Configure Path Manually') {
+        await vscode.commands.executeCommand('workbench.action.openSettings', 'mtlog.analyzerPath');
         vscode.window.showInformationMessage(
-            'Installing mtlog-analyzer... Please wait for the installation to complete, then reload VS Code.',
-            'Reload Window'
+            'Please set the full path to mtlog-analyzer in the settings.',
+            'Show Instructions'
         ).then(selection => {
-            if (selection === 'Reload Window') {
-                vscode.commands.executeCommand('workbench.action.reloadWindow');
+            if (selection === 'Show Instructions') {
+                const gopath = process.env.GOPATH || path.join(os.homedir(), 'go');
+                const expectedPath = path.join(gopath, 'bin', os.platform() === 'win32' ? 'mtlog-analyzer.exe' : 'mtlog-analyzer');
+                vscode.window.showInformationMessage(
+                    `After installing with 'go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest', the analyzer will be at:\n\n${expectedPath}`
+                );
             }
         });
-    } else {
-        // Download pre-built binary
-        const platform = os.platform();
-        const arch = os.arch();
-        let binaryUrl = '';
-        let binaryName = 'mtlog-analyzer';
-        
-        // Check if we have a pre-built binary for this architecture
-        const supportedArch = (arch === 'x64' || arch === 'amd64') ? 'amd64' : null;
-        
-        if (!supportedArch) {
-            vscode.window.showWarningMessage(
-                `Pre-built binaries are only available for amd64/x64 architecture. Your system is ${arch}.\n\nPlease install via Go instead: go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest`,
-                'Install with Go'
-            ).then(selection => {
-                if (selection === 'Install with Go') {
-                    const terminal = vscode.window.createTerminal('Install mtlog-analyzer');
-                    terminal.show();
-                    terminal.sendText('go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest');
+        return;
+    }
+    
+    if (installMethod === 'Install with Go (recommended)') {
+        // Show progress notification
+        vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: "Installing mtlog-analyzer",
+            cancellable: false
+        }, async (progress) => {
+            progress.report({ increment: 0, message: "Running go install..." });
+            
+            try {
+                // Run go install
+                execSync('go install github.com/willibrandon/mtlog/cmd/mtlog-analyzer@latest', {
+                    encoding: 'utf8',
+                    env: { ...process.env }
+                });
+                
+                progress.report({ increment: 100, message: "Installation complete!" });
+                
+                // Try to find the installed analyzer
+                const installedPath = await findAnalyzer();
+                if (installedPath) {
+                    const config = vscode.workspace.getConfiguration('mtlog');
+                    await config.update('analyzerPath', installedPath, vscode.ConfigurationTarget.Global);
+                    
+                    vscode.window.showInformationMessage(
+                        `mtlog-analyzer installed successfully at: ${installedPath}`,
+                        'Reload Window'
+                    ).then(selection => {
+                        if (selection === 'Reload Window') {
+                            vscode.commands.executeCommand('workbench.action.reloadWindow');
+                        }
+                    });
+                } else {
+                    vscode.window.showWarningMessage(
+                        'Installation completed but analyzer not found in expected locations. You may need to reload VS Code.',
+                        'Reload Window'
+                    ).then(selection => {
+                        if (selection === 'Reload Window') {
+                            vscode.commands.executeCommand('workbench.action.reloadWindow');
+                        }
+                    });
                 }
-            });
-            return;
-        }
-        
-        if (platform === 'win32') {
-            binaryName = 'mtlog-analyzer.exe';
-            binaryUrl = 'https://github.com/willibrandon/mtlog/releases/latest/download/mtlog-analyzer-windows-amd64.exe';
-        } else if (platform === 'darwin') {
-            binaryUrl = 'https://github.com/willibrandon/mtlog/releases/latest/download/mtlog-analyzer-darwin-amd64';
-        } else {
-            binaryUrl = 'https://github.com/willibrandon/mtlog/releases/latest/download/mtlog-analyzer-linux-amd64';
-        }
-        
-        vscode.window.showInformationMessage(
-            `Please download mtlog-analyzer from: ${binaryUrl}\n\nThen update your VS Code settings with the path to the binary.`,
-            'Open Settings'
-        ).then(selection => {
-            if (selection === 'Open Settings') {
-                vscode.commands.executeCommand('workbench.action.openSettings', 'mtlog.analyzerPath');
+            } catch (error) {
+                vscode.window.showErrorMessage(
+                    `Failed to install mtlog-analyzer: ${error}. Please check the output for details.`
+                );
+                VSCodeMtlogLogger.error('Installation failed', error as Error);
             }
         });
     }


### PR DESCRIPTION
## Description
Implements intelligent analyzer detection and streamlined installation experience for both VS Code and GoLand extensions. The extensions now automatically search standard Go installation locations and provide one-click installation when mtlog-analyzer is not found. Also fixes a critical Go version format issue that was preventing installation.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Checklist
- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [ ] Benchmarks checked (if performance-related)
- [x] Documentation updated (if needed)
- [ ] Zero-allocation promise maintained (if applicable)

## Additional notes
- Fixes #22 - PATH issues on macOS when VS Code launched from dock
- Critical fix: Invalid Go version format (1.23.0 → 1.23) was blocking `go install`
- Both extensions now search: `$GOBIN`, `$GOPATH/bin`, `~/go/bin`, PATH, and platform-specific locations
- VS Code: Added smart caching of found analyzer path for performance
- GoLand: Made `findAnalyzerPath()` internal for testing
- Updated tests to handle new auto-detection behavior