### PR TITLE
fix(neovim): fix lazy.nvim compatibility by using .vim extension (#32)

### DIFF
--- a/neovim-plugin/plugin/mtlog.vim
+++ b/neovim-plugin/plugin/mtlog.vim
@@ -1,10 +1,13 @@
--- Plugin initialization for mtlog.nvim
--- This file is automatically loaded by Neovim
+" Plugin initialization for mtlog.nvim
+" This file is automatically loaded by Neovim
 
-if vim.g.loaded_mtlog then
-  return
-end
-vim.g.loaded_mtlog = 1
+if exists('g:loaded_mtlog')
+  finish
+endif
+let g:loaded_mtlog = 1
+
+lua << EOF
+-- Begin Lua code
 
 -- Create user commands
 vim.api.nvim_create_user_command('MtlogAnalyze', function(opts)
@@ -623,3 +626,6 @@ vim.api.nvim_create_autocmd({ 'FileType' }, {
 })
 
 -- LSP integration is now handled by the lsp_integration module during setup
+
+EOF
+" End of plugin/mtlog.vim

--- a/neovim-plugin/tests/spec/commands_spec.lua
+++ b/neovim-plugin/tests/spec/commands_spec.lua
@@ -17,7 +17,7 @@ describe('mtlog commands', function()
     vim.g.mtlog_analyzer_path = vim.fn.exepath('echo')  -- Use echo as mock analyzer
     
     -- Load the plugin commands (normally loaded automatically by Neovim)
-    vim.cmd('runtime plugin/mtlog.lua')
+    vim.cmd('runtime plugin/mtlog.vim')
     
     -- Load the plugin
     mtlog = require('mtlog')


### PR DESCRIPTION
## Description
Fixes compatibility issue with lazy.nvim and other plugin managers where commands were not automatically loaded due to `.lua` file extension in the `plugin/` directory. Plugin managers expect `.vim` extensions for auto-sourced files.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Checklist
- [x] Tests pass (`./run_tests.sh` - all 116 tests passing)
- [x] Linter passes (N/A - Lua changes only)
- [ ] Benchmarks checked (if performance-related)
- [ ] Documentation updated (if needed)
- [ ] Zero-allocation promise maintained (if applicable)

## Additional notes
- Renamed `plugin/mtlog.lua` to `plugin/mtlog.vim`
- Wrapped Lua code in vim heredoc to follow Neovim plugin conventions
- Updated test suite to load the renamed file
- This ensures the plugin works out-of-the-box with all major plugin managers (lazy.nvim, packer, vim-plug)

Fixes #32