### PR TITLE
Add With() method for structured field logging (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ mtlog is a high-performance structured logging library for Go, inspired by [Seri
 - **Message templates** with positional property extraction and format specifiers
 - **Go template syntax** support (`{{.Property}}`) alongside traditional syntax
 - **OpenTelemetry compatibility** with support for dotted property names (`{http.method}`, `{service.name}`)
+- **Structured fields** via `With()` method for slog-style key-value pairs
 - **Output templates** for customizable log formatting
 - **ForType logging** with automatic SourceContext from Go types and intelligent caching
 - **LogContext scoped properties** that flow through operation contexts
@@ -249,6 +250,10 @@ log := mtlog.New(
     mtlog.WithSourceContext(), // Auto-detect logger context
 )
 
+// Structured fields with With() - slog-style
+log.With("service", "auth", "version", "1.0").Info("Service started")
+log.With("user_id", 123, "request_id", "abc-123").Info("Processing request")
+
 // Context-based enrichment
 ctx := context.WithValue(context.Background(), "RequestId", "abc-123")
 log.ForContext("UserId", userId).Information("Processing request")
@@ -264,6 +269,54 @@ userLogger.Information("User operation") // SourceContext: "User"
 orderLogger := mtlog.ForType[OrderService](log)
 orderLogger.Information("Processing order") // SourceContext: "OrderService"
 ```
+
+## Structured Fields with With()
+
+The `With()` method provides a convenient way to add structured fields to log events, following the slog convention of accepting variadic key-value pairs:
+
+```go
+// Basic usage with key-value pairs
+logger.With("service", "api", "version", "1.0").Info("Service started")
+
+// Chaining With() calls
+logger.
+    With("environment", "production").
+    With("region", "us-west-2").
+    Info("Deployment complete")
+
+// Create a base logger with common fields
+apiLogger := logger.With(
+    "component", "api",
+    "host", "api-server-01",
+)
+
+// Reuse the base logger for multiple operations
+apiLogger.Info("Handling request")
+apiLogger.With("endpoint", "/users").Info("GET /users")
+apiLogger.With("endpoint", "/products", "method", "POST").Info("POST /products")
+
+// Request-scoped logging
+requestLogger := apiLogger.With(
+    "request_id", "abc-123",
+    "user_id", 456,
+)
+requestLogger.Info("Request started")
+requestLogger.With("duration_ms", 42).Info("Request completed")
+
+// Combine With() and ForContext()
+logger.
+    With("service", "payment").
+    ForContext("transaction_id", "tx-789").
+    With("amount", 99.99, "currency", "USD").
+    Info("Payment processed")
+```
+
+### With() vs ForContext()
+
+- **With()**: Accepts variadic key-value pairs (slog-style), convenient for multiple fields
+- **ForContext()**: Takes a single property name and value, returns a new logger
+- Both methods create a new logger instance with the combined properties
+- Both are safe for concurrent use
 
 ## LogContext - Scoped Properties
 

--- a/adapters/otel/bridge_test.go
+++ b/adapters/otel/bridge_test.go
@@ -74,6 +74,11 @@ func (m *mockLogger) WithContext(ctx context.Context) core.Logger {
 	return m
 }
 
+func (m *mockLogger) With(args ...any) core.Logger {
+	// For testing, just return self
+	return m
+}
+
 func (m *mockLogger) Info(template string, args ...any) {
 	m.Information(template, args...)
 }

--- a/adapters/otel/fuzz_test.go
+++ b/adapters/otel/fuzz_test.go
@@ -284,5 +284,6 @@ func (m *mockFuzzLogger) Fatal(template string, args ...any) {}
 func (m *mockFuzzLogger) Write(level core.LogEventLevel, template string, args ...any) {}
 func (m *mockFuzzLogger) ForContext(propertyName string, value any) core.Logger { return m }
 func (m *mockFuzzLogger) WithContext(ctx context.Context) core.Logger { return m }
+func (m *mockFuzzLogger) With(args ...any) core.Logger { return m }
 func (m *mockFuzzLogger) Info(template string, args ...any) {}
 func (m *mockFuzzLogger) Warn(template string, args ...any) {}

--- a/core/logger.go
+++ b/core/logger.go
@@ -32,6 +32,12 @@ type Logger interface {
 	// WithContext creates a logger that enriches events with context values.
 	WithContext(ctx context.Context) Logger
 
+	// With creates a logger that enriches events with the specified key-value pairs.
+	// Keys must be strings. Values can be any type.
+	// The key-value pairs should be provided in the order: key1, value1, key2, value2, ...
+	// If an odd number of arguments is provided, the last argument is ignored.
+	With(args ...any) Logger
+
 	// IsEnabled returns true if events at the specified level would be processed.
 	IsEnabled(level LogEventLevel) bool
 

--- a/examples/with/main.go
+++ b/examples/with/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"time"
+
+	"github.com/willibrandon/mtlog"
+	"github.com/willibrandon/mtlog/core"
+)
+
+func main() {
+	// Create a logger with console output
+	logger := mtlog.New(
+		mtlog.WithConsole(),
+		mtlog.WithMinimumLevel(core.InformationLevel),
+	)
+
+	// Example 1: Basic With() usage
+	logger.With("service", "auth", "version", "1.0").Info("Service started")
+
+	// Example 2: Chaining With() calls
+	logger.
+		With("environment", "production").
+		With("region", "us-west-2").
+		Info("Deployment complete")
+
+	// Example 3: Creating a common logger with shared fields
+	apiLogger := logger.With(
+		"component", "api",
+		"host", "api-server-01",
+	)
+
+	// Use the common logger for multiple operations
+	apiLogger.Info("Handling request")
+	apiLogger.With("endpoint", "/users").Info("GET /users")
+	apiLogger.With("endpoint", "/products", "method", "POST").Info("POST /products")
+
+	// Example 4: Request-scoped logging
+	requestLogger := apiLogger.With(
+		"request_id", "abc-123",
+		"user_id", 456,
+		"timestamp", time.Now().Unix(),
+	)
+
+	requestLogger.Info("Request started")
+	requestLogger.With("duration_ms", 42).Info("Request completed")
+
+	// Example 5: Combining With() and ForContext()
+	logger.
+		With("service", "payment").
+		ForContext("transaction_id", "tx-789").
+		With("amount", 99.99, "currency", "USD").
+		Info("Payment processed")
+
+	// Example 6: Error logging with context
+	err := processOrder("order-123")
+	if err != nil {
+		logger.
+			With("order_id", "order-123").
+			With("error_type", "validation").
+			Error("Failed to process order: {Error}", err)
+	}
+
+	// Example 7: Structured logging for metrics
+	metricsLogger := logger.With("metric_type", "performance")
+	
+	metricsLogger.With(
+		"operation", "database_query",
+		"duration_ms", 15,
+		"rows_returned", 42,
+	).Info("Query executed")
+
+	metricsLogger.With(
+		"operation", "cache_lookup",
+		"hit", true,
+		"latency_ns", 1500,
+	).Info("Cache accessed")
+
+	// Example 8: Dynamic field addition
+	baseLogger := logger.With("app", "example")
+	for i := 0; i < 3; i++ {
+		baseLogger.With("iteration", i, "timestamp", time.Now().UnixNano()).
+			Info("Processing iteration")
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func processOrder(orderID string) error {
+	// Simulate order processing
+	_ = orderID // Mark as used
+	return nil
+}

--- a/with_bench_test.go
+++ b/with_bench_test.go
@@ -1,0 +1,184 @@
+package mtlog
+
+import (
+	"testing"
+
+	"github.com/willibrandon/mtlog/core"
+	"github.com/willibrandon/mtlog/sinks"
+)
+
+func BenchmarkWith(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("NoFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With().Info("test message")
+		}
+	})
+
+	b.Run("TwoFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With("key1", "value1", "key2", 42).Info("test message")
+		}
+	})
+
+	b.Run("FourFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With(
+				"key1", "value1",
+				"key2", 42,
+				"key3", true,
+				"key4", 3.14,
+			).Info("test message")
+		}
+	})
+
+	b.Run("EightFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With(
+				"key1", "value1",
+				"key2", 42,
+				"key3", true,
+				"key4", 3.14,
+				"key5", "value5",
+				"key6", 100,
+				"key7", false,
+				"key8", 2.71,
+			).Info("test message")
+		}
+	})
+
+	b.Run("TenFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With(
+				"key1", "value1",
+				"key2", 42,
+				"key3", true,
+				"key4", 3.14,
+				"key5", "value5",
+				"key6", 100,
+				"key7", false,
+				"key8", 2.71,
+				"key9", "value9",
+				"key10", 999,
+			).Info("test message")
+		}
+	})
+
+	b.Run("ChainedWith", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.
+				With("service", "api").
+				With("version", "1.0").
+				With("environment", "production").
+				Info("test message")
+		}
+	})
+}
+
+func BenchmarkWithVsForContext(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("With", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With("user_id", 123, "request_id", "abc").Info("test message")
+		}
+	})
+
+	b.Run("ForContext", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.
+				ForContext("user_id", 123).
+				ForContext("request_id", "abc").
+				Info("test message")
+		}
+	})
+}
+
+func BenchmarkWithCreation(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("CreateLoggerNoFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = logger.With()
+		}
+	})
+
+	b.Run("CreateLoggerTwoFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = logger.With("key1", "value1", "key2", 42)
+		}
+	})
+
+	b.Run("CreateLoggerEightFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = logger.With(
+				"key1", "value1",
+				"key2", 42,
+				"key3", true,
+				"key4", 3.14,
+				"key5", "value5",
+				"key6", 100,
+				"key7", false,
+				"key8", 2.71,
+			)
+		}
+	})
+}
+
+func BenchmarkWithReuse(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	// Create a logger with common fields once
+	commonLogger := logger.With("service", "api", "version", "1.0")
+
+	b.Run("ReuseCommonLogger", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			commonLogger.With("request_id", i).Info("test message")
+		}
+	})
+
+	b.Run("RecreateEachTime", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With("service", "api", "version", "1.0", "request_id", i).Info("test message")
+		}
+	})
+}

--- a/with_isolated_test.go
+++ b/with_isolated_test.go
@@ -1,0 +1,217 @@
+package mtlog
+
+import (
+	"testing"
+
+	"github.com/willibrandon/mtlog/core"
+	"github.com/willibrandon/mtlog/sinks"
+)
+
+// TestWithAllocations verifies that With() achieves 2 allocations
+// (1 for logger struct, 1 for fields array)
+// 
+// Note: Unlike zap which pre-serializes to achieve 1 allocation,
+// mtlog maintains structured properties for pipeline flexibility.
+func TestWithAllocations(t *testing.T) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	t.Run("TwoFields", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = logger.With("key1", "value1", "key2", 42)
+		})
+		
+		t.Logf("With(2 fields) allocations: %.1f", allocs)
+		if allocs > 2 {
+			t.Errorf("Expected 2 allocations, got %.1f", allocs)
+		}
+	})
+
+	t.Run("FourFields", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = logger.With("key1", "value1", "key2", 42, "key3", true, "key4", 3.14)
+		})
+		
+		t.Logf("With(4 fields) allocations: %.1f", allocs)
+		if allocs > 2 {
+			t.Errorf("Expected 2 allocations, got %.1f", allocs)
+		}
+	})
+
+	t.Run("EightFields", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = logger.With(
+				"f1", "v1", "f2", 2, "f3", true, "f4", 3.14,
+				"f5", "v5", "f6", 6, "f7", false, "f8", 8.0,
+			)
+		})
+		
+		t.Logf("With(8 fields) allocations: %.1f", allocs)
+		if allocs > 2 {
+			t.Errorf("Expected 2 allocations, got %.1f", allocs)
+		}
+	})
+
+	t.Run("ChainedWith", func(t *testing.T) {
+		base := logger.With("service", "api")
+		
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = base.With("request_id", "abc-123")
+		})
+		
+		t.Logf("Chained With() allocations: %.1f", allocs)
+		// Chained operations need to merge fields, so may have more allocations
+		if allocs > 4 {
+			t.Errorf("Expected <=4 allocations, got %.1f", allocs)
+		}
+	})
+
+	t.Run("WithOverride", func(t *testing.T) {
+		base := logger.With("user_id", 123)
+		
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = base.With("user_id", 456) // Override
+		})
+		
+		t.Logf("With() override allocations: %.1f", allocs)
+		// Override operations need to scan existing fields
+		if allocs > 4 {
+			t.Errorf("Expected <=4 allocations, got %.1f", allocs)
+		}
+	})
+}
+
+// BenchmarkWithOnly benchmarks only the With() operation, not logging
+func BenchmarkWithOnly(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("NoFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.With()
+		}
+		_ = l
+	})
+
+	b.Run("TwoFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.With("key1", "value1", "key2", 42)
+		}
+		_ = l
+	})
+
+	b.Run("FourFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.With(
+				"key1", "value1",
+				"key2", 42,
+				"key3", true,
+				"key4", 3.14,
+			)
+		}
+		_ = l
+	})
+
+	b.Run("EightFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.With(
+				"key1", "value1",
+				"key2", 42,
+				"key3", true,
+				"key4", 3.14,
+				"key5", "value5",
+				"key6", 100,
+				"key7", false,
+				"key8", 2.71,
+			)
+		}
+		_ = l
+	})
+
+	b.Run("SixteenFields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.With(
+				"f1", "v1", "f2", 2, "f3", true, "f4", 4.0,
+				"f5", "v5", "f6", 6, "f7", false, "f8", 8.0,
+				"f9", "v9", "f10", 10, "f11", true, "f12", 12.0,
+				"f13", "v13", "f14", 14, "f15", false, "f16", 16.0,
+			)
+		}
+		_ = l
+	})
+
+	b.Run("ChainedWith", func(b *testing.B) {
+		base := logger.With("service", "api", "version", "1.0")
+		
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = base.With("request_id", i)
+		}
+		_ = l
+	})
+}
+
+// BenchmarkWithComparison compares different With patterns
+func BenchmarkWithComparison(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("ForContext_SingleField", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.ForContext("request_id", i)
+		}
+		_ = l
+	})
+
+	b.Run("With_SingleField", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		var l core.Logger
+		for i := 0; i < b.N; i++ {
+			l = logger.With("request_id", i)
+		}
+		_ = l
+	})
+
+	b.Run("With_ThenLog", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.With("request_id", i, "user_id", i*2).Info("test")
+		}
+	})
+
+	b.Run("DirectLog_WithProperties", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger.Info("test {RequestId} {UserId}", i, i*2)
+		}
+	})
+}

--- a/with_perf_test.go
+++ b/with_perf_test.go
@@ -1,0 +1,122 @@
+package mtlog
+
+import (
+	"testing"
+
+	"github.com/willibrandon/mtlog/core"
+	"github.com/willibrandon/mtlog/sinks"
+)
+
+// BenchmarkWithPerformance validates that With() meets our performance targets
+func BenchmarkWithPerformance(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("With_2Fields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		
+		for i := 0; i < b.N; i++ {
+			l := logger.With("key1", "value1", "key2", 42)
+			_ = l
+		}
+		
+		// Verify we achieve 2 allocations (logger + fields)
+		allocsPerOp := testing.AllocsPerRun(100, func() {
+			_ = logger.With("key1", "value1", "key2", 42)
+		})
+		
+		if allocsPerOp > 2 {
+			b.Errorf("Performance regression: expected 2 allocs, got %.2f allocs/op", allocsPerOp)
+		}
+	})
+
+	b.Run("With_8Fields", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		
+		for i := 0; i < b.N; i++ {
+			l := logger.With(
+				"field1", "value1",
+				"field2", 42,
+				"field3", true,
+				"field4", 3.14,
+				"field5", "value5",
+				"field6", 100,
+				"field7", false,
+				"field8", 2.71,
+			)
+			_ = l
+		}
+		
+		// Still should be 2 allocations
+		allocsPerOp := testing.AllocsPerRun(100, func() {
+			_ = logger.With(
+				"f1", 1, "f2", 2, "f3", 3, "f4", 4,
+				"f5", 5, "f6", 6, "f7", 7, "f8", 8,
+			)
+		})
+		
+		if allocsPerOp > 2 {
+			b.Errorf("Performance regression: expected 2 allocs, got %.2f allocs/op", allocsPerOp)
+		}
+	})
+
+	b.Run("ChainedWith", func(b *testing.B) {
+		base := logger.With("service", "api", "version", "1.0")
+		
+		b.ReportAllocs()
+		b.ResetTimer()
+		
+		for i := 0; i < b.N; i++ {
+			l := base.With("request_id", i, "user_id", i*2)
+			_ = l
+		}
+		
+		// Chained operations may need to merge fields
+		allocsPerOp := testing.AllocsPerRun(100, func() {
+			_ = base.With("request_id", 1, "user_id", 2)
+		})
+		
+		if allocsPerOp > 3 {
+			b.Errorf("Performance regression: expected <=3 allocs for chained With, got %.2f", allocsPerOp)
+		}
+	})
+}
+
+// BenchmarkWithRealWorld tests realistic usage patterns
+func BenchmarkWithRealWorld(b *testing.B) {
+	logger := New(
+		WithSink(sinks.NewMemorySink()),
+		WithMinimumLevel(core.InformationLevel),
+	)
+
+	b.Run("HTTPRequest", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		
+		for i := 0; i < b.N; i++ {
+			logger.With(
+				"method", "GET",
+				"path", "/api/users",
+				"status", 200,
+				"duration_ms", 42,
+				"user_id", 123,
+				"trace_id", "abc-xyz",
+			).Info("Request handled")
+		}
+	})
+
+	b.Run("BaseLogger_Reuse", func(b *testing.B) {
+		base := logger.With("service", "api", "env", "prod")
+		
+		b.ReportAllocs()
+		b.ResetTimer()
+		
+		for i := 0; i < b.N; i++ {
+			base.With("request_id", i).Info("Request {RequestId} handled", i)
+		}
+	})
+}

--- a/with_test.go
+++ b/with_test.go
@@ -1,0 +1,283 @@
+package mtlog
+
+import (
+	"testing"
+
+	"github.com/willibrandon/mtlog/core"
+	"github.com/willibrandon/mtlog/sinks"
+)
+
+func TestWith(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []any
+		expected map[string]any
+	}{
+		{
+			name:     "empty args",
+			args:     []any{},
+			expected: map[string]any{},
+		},
+		{
+			name:     "single pair",
+			args:     []any{"key1", "value1"},
+			expected: map[string]any{"key1": "value1"},
+		},
+		{
+			name:     "multiple pairs",
+			args:     []any{"key1", "value1", "key2", 42, "key3", true},
+			expected: map[string]any{"key1": "value1", "key2": 42, "key3": true},
+		},
+		{
+			name:     "odd number of args",
+			args:     []any{"key1", "value1", "key2"},
+			expected: map[string]any{"key1": "value1"},
+		},
+		{
+			name:     "non-string key",
+			args:     []any{123, "value1", "key2", "value2"},
+			expected: map[string]any{"key2": "value2"},
+		},
+		{
+			name:     "nil values",
+			args:     []any{"key1", nil, "key2", "value2"},
+			expected: map[string]any{"key1": nil, "key2": "value2"},
+		},
+		{
+			name:     "complex values",
+			args:     []any{"struct", struct{ Name string }{Name: "test"}, "slice", []int{1, 2, 3}},
+			expected: map[string]any{"struct": struct{ Name string }{Name: "test"}, "slice": []int{1, 2, 3}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a memory sink to capture events
+			memSink := sinks.NewMemorySink()
+			logger := New(
+				WithSink(memSink),
+				WithMinimumLevel(core.VerboseLevel),
+			)
+
+			// Create logger with With() method
+			withLogger := logger.With(tt.args...)
+
+			// Log a message
+			withLogger.Info("test message")
+
+			// Get captured events
+			events := memSink.Events()
+			if len(events) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(events))
+			}
+
+			// Verify properties
+			event := events[0]
+			for key, expectedValue := range tt.expected {
+				actualValue, exists := event.Properties[key]
+				if !exists {
+					t.Errorf("expected property %s not found", key)
+					continue
+				}
+				
+				// Compare values
+				if !compareValues(actualValue, expectedValue) {
+					t.Errorf("property %s: expected %v, got %v", key, expectedValue, actualValue)
+				}
+			}
+
+			// Check for unexpected properties
+			for key := range event.Properties {
+				if _, expected := tt.expected[key]; !expected {
+					t.Errorf("unexpected property %s found", key)
+				}
+			}
+		})
+	}
+}
+
+func TestWithChaining(t *testing.T) {
+	// Create a memory sink to capture events
+	memSink := sinks.NewMemorySink()
+	logger := New(
+		WithSink(memSink),
+		WithMinimumLevel(core.VerboseLevel),
+	)
+
+	// Chain multiple With() calls
+	logger.
+		With("service", "auth").
+		With("version", "1.0").
+		With("environment", "production").
+		Info("service started")
+
+	// Get captured events
+	events := memSink.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	// Verify all properties are present
+	event := events[0]
+	expected := map[string]any{
+		"service":     "auth",
+		"version":     "1.0",
+		"environment": "production",
+	}
+
+	for key, expectedValue := range expected {
+		actualValue, exists := event.Properties[key]
+		if !exists {
+			t.Errorf("expected property %s not found", key)
+			continue
+		}
+		if actualValue != expectedValue {
+			t.Errorf("property %s: expected %v, got %v", key, expectedValue, actualValue)
+		}
+	}
+}
+
+func TestWithOverride(t *testing.T) {
+	// Create a memory sink to capture events
+	memSink := sinks.NewMemorySink()
+	logger := New(
+		WithSink(memSink),
+		WithMinimumLevel(core.VerboseLevel),
+	)
+
+	// Test that later With() calls override earlier ones
+	logger.
+		With("user_id", 123).
+		With("user_id", 456). // Override
+		Info("user action")
+
+	// Get captured events
+	events := memSink.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	// Verify the property was overridden
+	event := events[0]
+	userID, exists := event.Properties["user_id"]
+	if !exists {
+		t.Error("expected property user_id not found")
+	} else if userID != 456 {
+		t.Errorf("expected user_id to be 456, got %v", userID)
+	}
+}
+
+func TestWithAndForContext(t *testing.T) {
+	// Create a memory sink to capture events
+	memSink := sinks.NewMemorySink()
+	logger := New(
+		WithSink(memSink),
+		WithMinimumLevel(core.VerboseLevel),
+	)
+
+	// Combine With() and ForContext()
+	logger.
+		With("service", "api").
+		ForContext("request_id", "abc-123").
+		With("user_id", 789).
+		Info("request processed")
+
+	// Get captured events
+	events := memSink.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	// Verify all properties are present
+	event := events[0]
+	expected := map[string]any{
+		"service":    "api",
+		"request_id": "abc-123",
+		"user_id":    789,
+	}
+
+	for key, expectedValue := range expected {
+		actualValue, exists := event.Properties[key]
+		if !exists {
+			t.Errorf("expected property %s not found", key)
+			continue
+		}
+		if actualValue != expectedValue {
+			t.Errorf("property %s: expected %v, got %v", key, expectedValue, actualValue)
+		}
+	}
+}
+
+func TestWithThreadSafety(t *testing.T) {
+	// Create a memory sink to capture events
+	memSink := sinks.NewMemorySink()
+	logger := New(
+		WithSink(memSink),
+		WithMinimumLevel(core.VerboseLevel),
+	)
+
+	// Create a logger with With()
+	baseLogger := logger.With("base", "value")
+
+	// Run concurrent operations
+	done := make(chan bool, 2)
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			baseLogger.With("goroutine", 1, "iteration", i).Info("message from goroutine 1")
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			baseLogger.With("goroutine", 2, "iteration", i).Info("message from goroutine 2")
+		}
+		done <- true
+	}()
+
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+
+	// Get captured events
+	events := memSink.Events()
+	if len(events) != 200 {
+		t.Fatalf("expected 200 events, got %d", len(events))
+	}
+
+	// Verify all events have the base property
+	for _, event := range events {
+		if base, exists := event.Properties["base"]; !exists || base != "value" {
+			t.Error("base property missing or incorrect")
+		}
+	}
+}
+
+// compareValues compares two values, handling special cases like slices and structs
+func compareValues(a, b any) bool {
+	// Simple equality check for most types
+	// For slices and structs, this will use Go's default comparison
+	// which works for our test cases
+	switch va := a.(type) {
+	case []int:
+		vb, ok := b.([]int)
+		if !ok || len(va) != len(vb) {
+			return false
+		}
+		for i := range va {
+			if va[i] != vb[i] {
+				return false
+			}
+		}
+		return true
+	case struct{ Name string }:
+		vb, ok := b.(struct{ Name string })
+		if !ok {
+			return false
+		}
+		return va.Name == vb.Name
+	default:
+		return a == b
+	}
+}


### PR DESCRIPTION
## Description
Adds the `With()` method for structured field logging, following slog conventions. This enables adding multiple key-value pairs to log events using variadic arguments.

**Key features:**
- Accepts variadic key-value pairs: `logger.With("service", "api", "version", "1.0")`
- Chainable for building context: `logger.With("env", "prod").With("region", "us-west-2")`
- Achieves 2 allocations for common cases (≤64 fields)
- Maintains structured properties for Serilog compatibility and pipeline flexibility

**Performance characteristics:**
- 0 allocations when no fields (returns same logger)
- 2 allocations for ≤64 fields (logger struct + fields array)
- ~50-150ns per operation
- Uses slice storage with map fallback for large field counts

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Documentation update

## Checklist
- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Benchmarks checked (if performance-related)
- [x] Documentation updated (if needed)
- [x] Zero-allocation promise maintained (if applicable)

## Additional notes
- **Design decision**: We achieve 2 allocations instead of zap's 1 because we maintain structured properties rather than pre-serializing to JSON. This preserves Serilog compatibility and enables property-based filtering, dynamic enrichment, and multiple output formats.
- **ForContext() now delegates to With()** for code reuse and consistency
- Includes edge case handling for odd arguments, non-string keys, and property overrides

Fixes #42 