### PR TITLE
fix: add RenderMessage() method for custom sinks (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **RenderMessage() Method** - Public API for rendering message templates (#64)
   - New `RenderMessage()` method on `core.LogEvent` for custom sinks
-  - Properly handles destructuring operators (`{@Property}`), scalar hints (`{$Property}`), and format specifiers (`{Property:format}`)
+  - Properly handles capturing operators (`{@Property}`), scalar hints (`{$Property}`), and format specifiers (`{Property:format}`)
   - Enables custom sinks to render message templates without accessing internal parser
   - Returns the original template as fallback if parsing fails
   - Example: `message := event.RenderMessage()` renders the template with all properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **RenderMessage() Method** - Public API for rendering message templates (#64)
+  - New `RenderMessage()` method on `core.LogEvent` for custom sinks
+  - Properly handles destructuring operators (`{@Property}`), scalar hints (`{$Property}`), and format specifiers (`{Property:format}`)
+  - Enables custom sinks to render message templates without accessing internal parser
+  - Returns the original template as fallback if parsing fails
+  - Example: `message := event.RenderMessage()` renders the template with all properties
+
 - **Zed Extension** - Full editor support via Language Server Protocol (#56)
   - New `mtlog-lsp` command providing LSP wrapper for mtlog-analyzer
   - Native Zed extension using Rust/WASM (wasm32-wasip2 target)

--- a/README.md
+++ b/README.md
@@ -1373,7 +1373,7 @@ type CustomSink struct {
 
 func (s *CustomSink) Emit(event *core.LogEvent) {
     // Use RenderMessage() to properly render the message template
-    // This handles format specifiers, destructuring operators, and scalar hints
+    // This handles format specifiers, capturing operators, and scalar hints
     message := event.RenderMessage()
 
     // Format and write the log entry

--- a/core/event.go
+++ b/core/event.go
@@ -39,7 +39,7 @@ func (e *LogEvent) AddProperty(name string, value any) {
 
 // RenderMessage renders the message template with the event's properties.
 // This method parses the MessageTemplate and replaces all placeholders with their
-// corresponding property values, handling format specifiers, destructuring operators,
+// corresponding property values, handling format specifiers, capturing operators,
 // and scalar hints.
 //
 // If parsing fails, the original MessageTemplate is returned as a fallback.

--- a/core/event.go
+++ b/core/event.go
@@ -1,6 +1,11 @@
 package core
 
-import "time"
+import (
+	"time"
+
+	"github.com/willibrandon/mtlog/internal/parser"
+	"github.com/willibrandon/mtlog/selflog"
+)
 
 // LogEvent represents a single log event with all its properties.
 type LogEvent struct {
@@ -30,4 +35,35 @@ func (e *LogEvent) AddPropertyIfAbsent(property *LogEventProperty) {
 // AddProperty adds or overwrites a property in the event.
 func (e *LogEvent) AddProperty(name string, value any) {
 	e.Properties[name] = value
+}
+
+// RenderMessage renders the message template with the event's properties.
+// This method parses the MessageTemplate and replaces all placeholders with their
+// corresponding property values, handling format specifiers, destructuring operators,
+// and scalar hints.
+//
+// If parsing fails, the original MessageTemplate is returned as a fallback.
+//
+// Example:
+//
+//	event := &LogEvent{
+//	    MessageTemplate: "User {UserId} logged in from {City}",
+//	    Properties: map[string]any{
+//	        "UserId": 123,
+//	        "City": "Seattle",
+//	    },
+//	}
+//	message := event.RenderMessage()  // "User 123 logged in from Seattle"
+func (e *LogEvent) RenderMessage() string {
+	tmpl, err := parser.Parse(e.MessageTemplate)
+	if err != nil {
+		// Log parsing error to selflog if enabled
+		if selflog.IsEnabled() {
+			selflog.Printf("[core] template parse error in RenderMessage: %v (template=%q)", err, e.MessageTemplate)
+		}
+		// Fallback to raw template on parse error
+		return e.MessageTemplate
+	}
+
+	return tmpl.Render(e.Properties)
 }

--- a/core/event_test.go
+++ b/core/event_test.go
@@ -7,7 +7,7 @@ import (
 // TestRenderMessage demonstrates that RenderMessage() fixes issue #64.
 // It shows that RenderMessage() correctly handles all template features.
 func TestRenderMessage(t *testing.T) {
-	t.Run("destructuring operator", func(t *testing.T) {
+	t.Run("capturing operator", func(t *testing.T) {
 		event := &LogEvent{
 			MessageTemplate: "Configuration: {@Config}",
 			Properties: map[string]any{

--- a/core/event_test.go
+++ b/core/event_test.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"testing"
+)
+
+// TestRenderMessage demonstrates that RenderMessage() fixes issue #64.
+// It shows that RenderMessage() correctly handles all template features.
+func TestRenderMessage(t *testing.T) {
+	t.Run("destructuring operator", func(t *testing.T) {
+		event := &LogEvent{
+			MessageTemplate: "Configuration: {@Config}",
+			Properties: map[string]any{
+				"Config": map[string]any{
+					"debug": true,
+					"port":  8080,
+				},
+			},
+		}
+
+		got := event.RenderMessage()
+		expected := "Configuration: map[debug:true port:8080]"
+
+		if got != expected {
+			t.Errorf("RenderMessage() = %q, want %q", got, expected)
+		}
+	})
+
+	t.Run("scalar hint", func(t *testing.T) {
+		event := &LogEvent{
+			MessageTemplate: "Values: {$Values}",
+			Properties: map[string]any{
+				"Values": []int{1, 2, 3},
+			},
+		}
+
+		got := event.RenderMessage()
+		expected := "Values: [1 2 3]"
+
+		if got != expected {
+			t.Errorf("RenderMessage() = %q, want %q", got, expected)
+		}
+	})
+
+	t.Run("format specifier", func(t *testing.T) {
+		event := &LogEvent{
+			MessageTemplate: "Count: {Count:000}",
+			Properties: map[string]any{
+				"Count": 42,
+			},
+		}
+
+		got := event.RenderMessage()
+		expected := "Count: 042"
+
+		if got != expected {
+			t.Errorf("RenderMessage() = %q, want %q", got, expected)
+		}
+	})
+
+	t.Run("simple properties", func(t *testing.T) {
+		event := &LogEvent{
+			MessageTemplate: "User {UserId} logged in from {City}",
+			Properties: map[string]any{
+				"UserId": 123,
+				"City":   "Seattle",
+			},
+		}
+
+		got := event.RenderMessage()
+		expected := "User 123 logged in from Seattle"
+
+		if got != expected {
+			t.Errorf("RenderMessage() = %q, want %q", got, expected)
+		}
+	})
+}

--- a/examples/custom-sink/main.go
+++ b/examples/custom-sink/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/willibrandon/mtlog"
+	"github.com/willibrandon/mtlog/core"
+)
+
+// CustomSink demonstrates using RenderMessage() to properly render message templates
+type CustomSink struct {
+	output *os.File
+}
+
+func (s *CustomSink) Emit(event *core.LogEvent) {
+	// Use RenderMessage() to properly render the message template
+	// This handles format specifiers, destructuring operators, and scalar hints
+	message := event.RenderMessage()
+
+	// Format and write the log entry
+	timestamp := event.Timestamp.Format("15:04:05")
+	levelStr := formatLevel(event.Level)
+
+	fmt.Fprintf(s.output, "[%s] %s: %s\n", timestamp, levelStr, message)
+
+	// Optionally include extra properties not in the template
+	for key, value := range event.Properties {
+		if !strings.Contains(event.MessageTemplate, "{"+key) {
+			fmt.Fprintf(s.output, "  → %s: %v\n", key, value)
+		}
+	}
+}
+
+func (s *CustomSink) Close() error {
+	return nil
+}
+
+func formatLevel(level core.LogEventLevel) string {
+	switch level {
+	case core.VerboseLevel:
+		return "VRB"
+	case core.DebugLevel:
+		return "DBG"
+	case core.InformationLevel:
+		return "INF"
+	case core.WarningLevel:
+		return "WRN"
+	case core.ErrorLevel:
+		return "ERR"
+	case core.FatalLevel:
+		return "FTL"
+	default:
+		return "???"
+	}
+}
+
+func main() {
+	// Create logger with custom sink
+	log := mtlog.New(
+		mtlog.WithSink(&CustomSink{output: os.Stdout}),
+		mtlog.WithMinimumLevel(core.DebugLevel),
+	)
+
+	// Simple message with properties
+	log.Info("Application started on port {Port}", 8080)
+
+	// Destructuring operator - renders the entire struct
+	config := map[string]any{
+		"debug":   true,
+		"port":    8080,
+		"timeout": 30,
+	}
+	log.Debug("Configuration: {@Config}", config)
+
+	// Scalar hint - renders as simple value
+	values := []int{10, 20, 30, 40, 50}
+	log.Info("Processing values: {$Values}", values)
+
+	// Format specifier - applies padding
+	log.Info("Order {OrderId:00000} processed", 42)
+
+	// Time formatting
+	log.Info("Event occurred at {Time:15:04:05}", time.Now())
+
+	// Multiple properties with format specifiers
+	log.Info("User {UserId:000} spent ${Amount:F2} on {ItemCount} items",
+		123, 49.95, 3)
+
+	// Properties not in template are shown separately
+	log.With("host", "api.example.com", "port", 443, "retry", 3).
+		Warning("Connection failed")
+
+	// Complex nested structures
+	user := struct {
+		ID   int
+		Name string
+		Tags []string
+	}{
+		ID:   789,
+		Name: "Alice",
+		Tags: []string{"premium", "verified"},
+	}
+	log.Info("User {@User} logged in", user)
+
+	fmt.Println("\n✅ Custom sink successfully using RenderMessage() to handle all template features!")
+}

--- a/examples/custom-sink/main.go
+++ b/examples/custom-sink/main.go
@@ -28,7 +28,19 @@ func (s *CustomSink) Emit(event *core.LogEvent) {
 
 	// Optionally include extra properties not in the template
 	for key, value := range event.Properties {
-		if !strings.Contains(event.MessageTemplate, "{"+key) {
+		// Check for complete placeholder patterns to avoid false positives
+		// (e.g., "User" should not match "{UserId}")
+		placeholder1 := "{" + key + "}"        // Simple: {Key}
+		placeholder2 := "{" + key + ":"        // With format: {Key:format}
+		placeholder3 := "{@" + key + "}"       // Destructuring: {@Key}
+		placeholder4 := "{$" + key + "}"       // Scalar: {$Key}
+		placeholder5 := "{" + key + ","        // Alignment: {Key,10}
+
+		if !strings.Contains(event.MessageTemplate, placeholder1) &&
+			!strings.Contains(event.MessageTemplate, placeholder2) &&
+			!strings.Contains(event.MessageTemplate, placeholder3) &&
+			!strings.Contains(event.MessageTemplate, placeholder4) &&
+			!strings.Contains(event.MessageTemplate, placeholder5) {
 			fmt.Fprintf(s.output, "  → %s: %v\n", key, value)
 		}
 	}

--- a/examples/custom-sink/main.go
+++ b/examples/custom-sink/main.go
@@ -17,7 +17,7 @@ type CustomSink struct {
 
 func (s *CustomSink) Emit(event *core.LogEvent) {
 	// Use RenderMessage() to properly render the message template
-	// This handles format specifiers, destructuring operators, and scalar hints
+	// This handles format specifiers, capturing operators, and scalar hints
 	message := event.RenderMessage()
 
 	// Format and write the log entry
@@ -32,7 +32,7 @@ func (s *CustomSink) Emit(event *core.LogEvent) {
 		// (e.g., "User" should not match "{UserId}")
 		placeholder1 := "{" + key + "}"        // Simple: {Key}
 		placeholder2 := "{" + key + ":"        // With format: {Key:format}
-		placeholder3 := "{@" + key + "}"       // Destructuring: {@Key}
+		placeholder3 := "{@" + key + "}"       // Capturing: {@Key}
 		placeholder4 := "{$" + key + "}"       // Scalar: {$Key}
 		placeholder5 := "{" + key + ","        // Alignment: {Key,10}
 
@@ -79,7 +79,7 @@ func main() {
 	// Simple message with properties
 	log.Info("Application started on port {Port}", 8080)
 
-	// Destructuring operator - renders the entire struct
+	// Capturing operator - renders the entire struct
 	config := map[string]any{
 		"debug":   true,
 		"port":    8080,


### PR DESCRIPTION
## Description
Adds a public `RenderMessage()` method to `core.LogEvent` to allow custom sinks to properly render message templates. This fixes issue #64 where custom sinks had to use manual string replacement that failed with destructuring operators (`{@Property}`), scalar hints (`{$Property}`), and format specifiers (`{Property:format}`).

The implementation follows Serilog's approach by providing a public API that handles all template rendering features. Also includes a refactor of `internal/parser/token.go` to resolve an import cycle by using interface-based design.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Documentation update

## Checklist
- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [ ] Benchmarks checked (if performance-related)
- [x] Documentation updated (if needed)
- [x] Zero-allocation promise maintained (if applicable)

## Additional notes
- Fixes #64 
- Added test coverage in `core/event_test.go`
- Created working example in `examples/custom-sink/main.go`
- Updated README.md and CHANGELOG.md with the new feature
- Refactored parser to use `fmt.Stringer` interface instead of concrete types to break import cycle